### PR TITLE
Use env utility in shebang

### DIFF
--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#!/usr/bin/env python3
 #
 # bank2ynab.py
 #


### PR DESCRIPTION
Rather than have users specify which Python interpreter via the command line, we can allow the env utility to do this.

If `python3 ./bank2ynab.py` worked for the user, then `./bank2ynab.py` should also work for the user after this change.

[Made a GIF 😬](https://i.imgur.com/BA6duoF.gif)