### PR TITLE
Add support for US Bank of America

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Here is a list of the banks and their formats that we already support. Note that
 1. UK Co-operative Bank
 1. UK first direct checking
 1. UK Monzo checking
+1. US Bank of America
 1. US BB&T
 1. US Schwab
 1. US TB Bank

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -389,6 +389,15 @@ Source Filename Pattern = 20[0-9]{6}_[0-9]{8}
 Use Regex for Filename = True
 Input Columns = Date,Payee,Inflow,skip
 
+[US Bank of America]
+# stmt-12.csv
+Use Regex For Filename = True
+Source Filename Pattern = stmt(-\d+)?
+Header Rows = 7
+Input Columns = Date,Payee,Outflow,skip
+Date Format = %m/%d/%Y
+Source Filename Extension = .csv
+
 [US BB&T]
 # source: Issue #115
 # EXPORT.CSV


### PR DESCRIPTION
Adding support for [Bank of America](https://www.bankofamerica.com) CSV exports.

Bank of America aka (BOFA) doesn't have a separate inflow and outflow column.  Inflow and outflow is represented with a negative or positive number.

Ran unit-tests locally and everything is passing `python -m unittest discover -v`