### PR TITLE
Output path where it's looking for files

### DIFF
--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -358,7 +358,7 @@ class B2YBank(object):
             if files != [] and missing_dir is True:
                 s = ("\nFormat: {}\n\nError: Can't find download path: {}"
                      "\nTrying default path instead:\t {}")
-                logging.error(s.format(self.name, try_path, path))
+                logging.error(s.format(self.name, self.try_path, path))
         return files
 
     def read_data(self, file_path):

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -584,11 +584,13 @@ class Bank2Ynab(object):
 
         if files_processed == 0:
             if bank.missing_dir:
-                logging.info('"%s" directory not found, used default directory: "%s"',
+                logging.info(
+                    '"%s" directory not found, used default directory: "%s"',
                     bank.try_path, bank.path)
             logging.info('%s files found in %s', files_processed, bank.path)
         else:
-            logging.info("\nDone! {} files processed.\n".format(files_processed))
+            logging.info(
+                "\nDone! {} files processed.\n".format(files_processed))
 
 
 # Let's run this thing!


### PR DESCRIPTION
Regarding #243, displaying where it's looking for files
- Created a method in B2YBank `resolve_path`
- The directory path is now only resolved once
- Exposed `path`, `missing_dir` and `try_path`
- Exposing these fairly static attributes allows us to use them outside of the instance

### Example outputs:
With bogus `Source Path`
```bash
$ python3 ./bank2ynab.py
INFO "/Users/eloy/asdf" directory not found, used default directory: "/Users/eloy/Downloads"
INFO 0 files found in /Users/eloy/Downloads
```

With `Source Path` that exists
```bash
$ python3 ./bank2ynab.py
INFO 0 files found in /Users/eloy/Downloads
```

With file found
```bash
$ python3 ./bank2ynab.py
INFO
Parsing input file:  /Users/eloy/Downloads/stmt.csv (format: US Bank of America)
INFO Parsed 39 lines
INFO Writing output file: /Users/eloy/Downloads/fixed_stmt.csv
INFO
Done! 1 files processed.
```


Unit tests passing via `python -m unittest discover -v`