### PR TITLE
Add support for US Chase Credit Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Here is a list of the banks and their formats that we already support. Note that
 1. UK first direct checking
 1. UK Monzo checking
 1. US BB&T
+1. US Chase Credit Card
 1. US Schwab
 1. US TB Bank
 1. (software) Personal Capital

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -388,6 +388,17 @@ Header Rows = 1
 Footer Rows = 0
 Input Columns = Date,skip,skip,Payee,Inflow,skip
 
+[US Chase Credit Card]
+# Chase9999_Activity_Stmt_YYYYMMDD.CSV
+# Chase9999_RecentActivity_YYYYMMDD.CSV
+Source Filename Pattern = Chase[0-9]{4}_(Activity_Stmt|RecentActivity)_[0-9]{8}
+Source Filename Extension = .CSV
+Use Regex for Filename = True
+Header Rows = 1
+Footer Rows = 0
+Input Columns = skip,Date,skip,Memo,Inflow
+Date Format = %m/%d/%Y
+
 [US Schwab]
 # source: Issue #122
 Source Filename Pattern = unknown!


### PR DESCRIPTION
Adding support for Chase CSV exports

Ran unit-tests locally and everything is passing `python -m unittest discover -v`