### PR TITLE
Add support for US Bank of America Credit Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Here is a list of the banks and their formats that we already support. Note that
 1. UK Co-operative Bank
 1. UK first direct checking
 1. UK Monzo checking
+1. US Bank of America Credit Card
 1. US BB&T
 1. US Schwab
 1. US TB Bank

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -389,6 +389,16 @@ Source Filename Pattern = 20[0-9]{6}_[0-9]{8}
 Use Regex for Filename = True
 Input Columns = Date,Payee,Inflow,skip
 
+[US Bank of America Credit Card]
+# October2018_9999.CSV
+Source Filename Pattern = ((Jan|Febr)uary|March|April|May|(Ju(ne|ly))|August|((Sept|Nov|Dec)ember)|October)[0-9]{4}_[0-9]{4}
+Source Filename Extension = .csv
+Use Regex for Filename = True
+Header Rows = 1
+Footer Rows = 0
+Input Columns = Date,skip,Memo,skip,Inflow
+Date Format = %m/%d/%Y
+
 [US BB&T]
 # source: Issue #115
 # EXPORT.CSV


### PR DESCRIPTION
Adding support for BoA credit card CSV exports

Ran unit-tests locally and everything is passing `python -m unittest discover -v`