### PR TITLE
softer date parsing, combine multiple input columns, add support for [SK VUB]

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Here is a list of the banks and their formats that we already support. Note that
 1. SE Swedbank
 1. SG OCBC Bank
 1. SG POSB savings
+1. SK Tatra Banka
+1. SK VUB
 1. UK Barclaycard credit card
 1. UK Co-operative Bank
 1. UK first direct checking

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -476,3 +476,13 @@ Source CSV Delimiter = ,
 Input Columns = skip,Date,Inflow,skip,CDFlag,skip,skip,skip,Payee,skip,skip,skip,skip,skip,Memo
 Inflow or Outflow Indicator = 4,Kredit,Debet
 Date Format = %d.%m.%Y
+
+[SK VUB]
+Source Filename Pattern = SK030200[0-9]{16}_export_(of_movements_on_the_account|pohybov_na_ucte)
+Source Filename Extension = .CSV
+Use Regex For Filename = True
+Header Rows = 1
+Footer Rows = 0
+Source CSV Delimiter = ,
+Input Columns = Date,skip,Payee,skip,Payee,Inflow,skip,skip,skip,skip,skip,Memo,skip,skip,skip
+Date Format = %Y%m%d

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -411,19 +411,18 @@ class B2YBank(object):
 
     def _fix_row(self, row):
         """
-        rearrange a row of our file to match expected output format
+        rearrange a row of our file to match expected output format,
+        optionally combining multiple input columns into a single output column.
         :param row: list of values
         :return: list of values in correct output format
         """
         output = []
         for header in self.config["output_columns"]:
-            try:
-                # check to see if our output header exists in input
-                index = self.config["input_columns"].index(header)
-                cell = row[index]
-            except (ValueError, IndexError):
-                # header isn't in input, default to blank cell
-                cell = ""
+            # find all input columns with data for this output column
+            indices = filter(lambda i: self.config["input_columns"][i]==header, range(len(self.config["input_columns"])))
+            # fetch data from those input columns if they are not empty, and merge them
+            cell_parts = filter(lambda s: bool(s), map(lambda i: row[i], indices))
+            cell = " ".join(cell_parts)
             output.append(cell)
         return output
 

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -412,7 +412,7 @@ class B2YBank(object):
     def _fix_row(self, row):
         """
         rearrange a row of our file to match expected output format,
-        optionally combining multiple input columns into a single output column.
+        optionally combining multiple input columns into a single output column
         :param row: list of values
         :return: list of values in correct output format
         """

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -419,9 +419,11 @@ class B2YBank(object):
         output = []
         for header in self.config["output_columns"]:
             # find all input columns with data for this output column
-            indices = filter(lambda i: self.config["input_columns"][i]==header,
+            indices = filter(lambda i:
+                             self.config["input_columns"][i] == header,
                              range(len(self.config["input_columns"])))
-            # fetch data from those input columns if they are not empty, and merge them
+            # fetch data from those input columns if they are not empty,
+            # and merge them
             cell_parts = []
             for i in indices:
                 try:
@@ -487,7 +489,7 @@ class B2YBank(object):
             # do our actual date processing
             output_date = datetime.strftime(input_date, "%d/%m/%Y")
             row[date_col] = output_date
-        except (ValueError,IndexError):
+        except (ValueError, IndexError):
             pass
         return row
 

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -419,9 +419,16 @@ class B2YBank(object):
         output = []
         for header in self.config["output_columns"]:
             # find all input columns with data for this output column
-            indices = filter(lambda i: self.config["input_columns"][i]==header, range(len(self.config["input_columns"])))
+            indices = filter(lambda i: self.config["input_columns"][i]==header,
+                             range(len(self.config["input_columns"])))
             # fetch data from those input columns if they are not empty, and merge them
-            cell_parts = filter(lambda s: bool(s), map(lambda i: row[i], indices))
+            cell_parts = []
+            for i in indices:
+                try:
+                    if row[i].lstrip():
+                        cell_parts.append(row[i].lstrip())
+                except IndexError:
+                    pass
             cell = " ".join(cell_parts)
             output.append(cell)
         return output
@@ -468,8 +475,11 @@ class B2YBank(object):
         :param row: list of values
         :param date_format: date format string
         """
-        if date_format:
-            date_col = self.config["input_columns"].index("Date")
+        if not(date_format):
+            return(row)
+
+        date_col = self.config["input_columns"].index("Date")
+        try:
             if row[date_col] == "":
                 return row
             # parse our date according to provided formatting string
@@ -477,6 +487,8 @@ class B2YBank(object):
             # do our actual date processing
             output_date = datetime.strftime(input_date, "%d/%m/%Y")
             row[date_col] = output_date
+        except (ValueError,IndexError):
+            pass
         return row
 
     def _cd_flag_process(self, row, cd_flags):

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -266,8 +266,8 @@ def get_config_line(conf_obj, section_name, args):
 def find_directory(filepath):
     """ finds the downloads folder for the active user if filepath is not set
     """
-    if filepath is "":
-        if os.name is "nt":
+    if filepath == "":
+        if os.name == "nt":
             # Windows
             try:
                 import winreg
@@ -319,7 +319,7 @@ class B2YBank(object):
         missing_dir = False
         try_path = self.config["path"]
         path = ""
-        if file_pattern is not "":
+        if file_pattern != "":
             try:
                 path = find_directory(try_path)
             except FileNotFoundError:

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -474,7 +474,7 @@ class B2YBank(object):
             if row[date_col] == "":
                 return row
             # parse our date according to provided formatting string
-            input_date = datetime.strptime(row[date_col], date_format)
+            input_date = datetime.strptime(row[date_col].lstrip(), date_format)
             # do our actual date processing
             output_date = datetime.strftime(input_date, "%d/%m/%Y")
             row[date_col] = output_date


### PR DESCRIPTION
**New Pull Request**
Support for [SK VUB] and required improvements to the infrastructure.

**Reference Issue:**
(none)

**Description**
I am submitting two improvements that are 100% backwards compatible with the existing configuration, but add more flexibility.

1. Dates with leading white space are now allowed. Previously, such dates could not be parsed and would result in exception.

1. Multiple input columns now can be combined to a single output column, by repeating the name of the output column in the *Input columns* configuration:
`Input Columns = Date,skip,Payee,skip,Payee,Inflow,skip,skip,skip,skip,skip,Memo,skip,skip,skip`

1. Both changes were necessary to add support for [SK VUB] which I am submitting as well. The bank in question uses two different Payee columns for bank transfers, and card payments.

Thank you for the useful project.