### PR TITLE
Solve issue with trailing spaces in dates

### DIFF
--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -488,7 +488,7 @@ class B2YBank(object):
             if row[date_col] == "":
                 return row
             # parse our date according to provided formatting string
-            input_date = datetime.strptime(row[date_col].lstrip(), date_format)
+            input_date = datetime.strptime(row[date_col].strip(), date_format)
             # do our actual date processing
             output_date = datetime.strftime(input_date, "%d/%m/%Y")
             row[date_col] = output_date


### PR DESCRIPTION
**New Pull Request**

**Reference Issue:**
none

**Description**

I had an issue with trailing spaces in dates. (I'm trying to add Revolut Bank)
Example CSV:
```
Completed Date ; Description ; Paid Out (CHF) ; Paid In (CHF) ; Exchange Out; Exchange In; Balance (CHF); Category; Notes
Apr 26, 2019 ; Card Delivery Fee  ; 6.99 ;  ;  ;  ; 3.01; general; 
```
This change solves the issue.