### PR TITLE
Fix/lansforsakringar

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -466,7 +466,7 @@ Plugin = handelsbanken
 # source: survey response #43
 # Mitt konto senaste transaktioner 2019-05-28.csv
 Use Regex for Filename = True
-Source Filename Pattern = Mitt konto senaste transaktioner [0-9]{4}-[0-9]{2}-[0-9]{2}
+Source Filename Pattern = .+ senaste transaktioner [0-9]{4}-[0-9]{2}-[0-9]{2}
 Source CSV Delimiter = ;
 Header Rows = 1
 # "Bokföringsdatum";"Transaktionsdatum";"Transaktionstyp";"Meddelande";"Belopp";"Kontonummer";"Kontonamn";"";"Saldo";"Tillgängligt belopp"

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -470,7 +470,7 @@ Source Filename Pattern = .+ senaste transaktioner [0-9]{4}-[0-9]{2}-[0-9]{2}
 Source CSV Delimiter = ;
 Header Rows = 1
 # "Bokföringsdatum";"Transaktionsdatum";"Transaktionstyp";"Meddelande";"Belopp";"Kontonummer";"Kontonamn";"";"Saldo";"Tillgängligt belopp"
-Input Columns = skip,Date,skip,Memo,Inflow,skip,skip,skip,skip,skip
+Input Columns = skip,Date,skip,Payee,Inflow,skip,skip,skip,skip,skip
 
 [SE Nordea]
 # source: Issue #92


### PR DESCRIPTION
The Regex for the Swedish bank "Länsförsäkringar" is not correct. As each account can have a different name, it is instead better to use the ".+" qualifier than a statically typed account name.

The bank also used "Meddelande" (memo) as it's Payee for some reason. Therefore I also changed this to correctly correspond to the banks intention. This can be changed manually in YNAB by ticking the "Switch Payee and Memo" button, but why not automate it?
