### PR TITLE
Re-enable DE Deutsche Kreditbank checking in config

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -229,16 +229,15 @@ Source CSV Delimiter = ;
 Input Columns = Date,skip,skip,skip,skip,skip,Inflow,skip
 Date Format = %d.%m.%Y
 
-# disabling this until #182 has been resolved!
-# [DE Deutsche Kreditbank checking]
-# # source: Issue #132
-# # 1234567890.csv
-# Use Regex For Filename = True
-# Source Filename Pattern = [0-9]{10}
-# Header Rows = 7
-# Source CSV Delimiter = ;
-# Input Columns = skip,Date,Memo,Payee,skip,skip,skip,Inflow,skip,skip,skip
-# Date Format = %d.%m.%Y
+[DE Deutsche Kreditbank checking]
+# source: Issue #132
+# 1234567890.csv
+Use Regex For Filename = True
+Source Filename Pattern = [0-9]{10}
+Header Rows = 7
+Source CSV Delimiter = ;
+Input Columns = skip,Date,Memo,Payee,skip,skip,skip,Inflow,skip,skip,skip
+Date Format = %d.%m.%Y
 
 [DE Deutsche Kreditbank credit card]
 # source: Issue #132
@@ -721,4 +720,3 @@ Header Rows = 0
 Footer Rows = 0
 Input Columns = Date,skip,skip,skip,Payee,Outflow,Inflow,skip,skip,skip
 Date Format = %m/%d/%Y
-


### PR DESCRIPTION
**New Pull Request**

**Reference Issue:**
*#291*


**Description**
The Deutsche Kreditbank checking account section should be enabled in the config again

*Explain the changes that this pull request makes*
I have removed the comments from the Deutsche Kreditbank checking account section and thus enabled it again