### PR TITLE
Add support for german number formatting

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -15,6 +15,8 @@ Footer Rows = 0
 Input Columns = Date,Payee,Outflow,Inflow,Running Balance
 # (see https://docs.python.org/2/library/datetime.html#id1 for date format strings)
 Date Format =
+# Currently either de or empty for the default number formatting
+Number Format =
 Inflow or Outflow Indicator =
 # Output file formatting
 Output Columns = Date,Payee,Category,Memo,Outflow,Inflow
@@ -229,16 +231,16 @@ Source CSV Delimiter = ;
 Input Columns = Date,skip,skip,skip,skip,skip,Inflow,skip
 Date Format = %d.%m.%Y
 
-# disabling this until #182 has been resolved!
-# [DE Deutsche Kreditbank checking]
-# # source: Issue #132
-# # 1234567890.csv
-# Use Regex For Filename = True
-# Source Filename Pattern = [0-9]{10}
-# Header Rows = 7
-# Source CSV Delimiter = ;
-# Input Columns = skip,Date,Memo,Payee,skip,skip,skip,Inflow,skip,skip,skip
-# Date Format = %d.%m.%Y
+[DE Deutsche Kreditbank checking]
+# source: Issue #132
+# 1234567890.csv
+Use Regex For Filename = True
+Source Filename Pattern = [0-9]{10}
+Header Rows = 7
+Source CSV Delimiter = ;
+Input Columns = skip,Date,Memo,Payee,skip,skip,skip,Inflow,skip,skip,skip
+Date Format = %d.%m.%Y
+Number Format = de
 
 [DE Deutsche Kreditbank credit card]
 # source: Issue #132
@@ -249,6 +251,7 @@ Header Rows = 7
 Source CSV Delimiter = ;
 Input Columns = skip,skip,Date,Memo,Inflow,skip
 Date Format = %d.%m.%Y
+Number Format = de
 
 [DE ING-DiBa]
 Use Regex For Filename = True

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -236,6 +236,7 @@ def fix_conf_params(conf_obj, section_name):
         "regex": ["Use Regex For Filename", True, ""],
         "fixed_prefix": ["Output Filename Prefix", False, ""],
         "input_delimiter": ["Source CSV Delimiter", False, ""],
+        "input_number_format": ["Number Format", False, ""],
         "header_rows": ["Header Rows", False, ""],
         "footer_rows": ["Footer Rows", False, ""],
         "date_format": ["Date Format", False, ""],
@@ -358,6 +359,10 @@ def string_num_diff(str1, str2):
     difference = int(1000 * (num2 - num1))
     return difference
 
+
+def rreplace(s, old, new, occurrence):
+    li = s.rsplit(old, occurrence)
+    return new.join(li)
 
 # -- end of utilities
 
@@ -526,10 +531,20 @@ class B2YBank(object):
         convert , to . in inflow and outflow strings
         :param row: list of values
         """
+
         inflow_index = self.config["output_columns"].index("Inflow")
         outflow_index = self.config["output_columns"].index("Outflow")
-        row[inflow_index] = row[inflow_index].replace(",", ".")
-        row[outflow_index] = row[outflow_index].replace(",", ".")
+
+        if (self.config["input_number_format"] == "de"):
+            row[inflow_index] = rreplace(
+                row[inflow_index], ",", "c", 1).replace(
+                ".", "").replace("c", ".")
+            row[outflow_index] = rreplace(
+                row[outflow_index], ",", "c", 1).replace(
+                ".", "").replace("c", ".")
+        else:
+            row[inflow_index] = row[inflow_index].replace(",", ".")
+            row[outflow_index] = row[outflow_index].replace(",", ".")
 
         return row
 


### PR DESCRIPTION
**New Pull Request**

**Reference Issue:**
*#293*

**Description**
German numbers formatted like 1.200,00 are now supported by a new config option called "Number Format".

*Explain the changes that this pull request makes*
Due to German number formatting, amounts were outputted like this: 1.200.00, thus failing YNAB import. I have added a new config option "Number Format" currently supporting "de" and just empty. If it is "de", the numbers will be formatted correctly now. I have also edited the default config sections for DKB checking and DKB credit card accounts (the only German banks I was able to verify this issue with).