### PR TITLE
Fixes #293 number formatting issue

### DIFF
--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -524,12 +524,17 @@ class B2YBank(object):
     def _fix_decimal_point(self, row):
         """
         convert , to . in inflow and outflow strings
+        then remove every instance of . except last one
         :param row: list of values
         """
         inflow_index = self.config["output_columns"].index("Inflow")
         outflow_index = self.config["output_columns"].index("Outflow")
-        row[inflow_index] = row[inflow_index].replace(",", ".")
-        row[outflow_index] = row[outflow_index].replace(",", ".")
+        inflow = row[inflow_index].replace(",", ".")
+        outflow = row[outflow_index].replace(",", ".")
+        dot_count = inflow.count(".") - 1
+        row[inflow_index] = inflow.replace(".", "", dot_count)
+        dot_count = outflow.count(".") - 1
+        row[outflow_index] = outflow.replace(".", "", dot_count)
 
         return row
 


### PR DESCRIPTION
**Reference Issue:**
Fixes #293 

**Description**
As from #293: 
> Transactions with amounts bigger than 999€ get imported without a value

Thanks for flagging the issue, @lukkigi!

*Explain the changes that this pull request makes*
Changes fix_decimal_point code (alternative to #294). Replaces every instance of "." in output number except for last instance. Allows for long German-formatted numbers, e.g. 123.567,89 which was previously being processed as 123.567.89. Once the fix_decimal_point function is finished its conversion, we just remove every instance of "." except for the last. That should allow for different arbitrary number separators in future if they occur in different formats and avoids any additional functions.

New fix_decimal_point code for reference:

```
def _fix_decimal_point(self, row):
        """
        convert , to . in inflow and outflow strings
        then remove every instance of . except last one
        :param row: list of values
        """
        inflow_index = self.config["output_columns"].index("Inflow")
        outflow_index = self.config["output_columns"].index("Outflow")        
        inflow = row[inflow_index].replace(",", ".")
        outflow = row[outflow_index].replace(",", ".")        
        dot_count = inflow.count(".") - 1
        row[inflow_index] = inflow.replace(".", "", dot_count)
        dot_count = outflow.count(".") - 1
        row[outflow_index] = outflow.replace(".", "", dot_count)

        return row
```