### PR TITLE
Feature to set date format language

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -15,6 +15,7 @@ Footer Rows = 0
 Input Columns = Date,Payee,Outflow,Inflow,Running Balance
 # (see https://docs.python.org/2/library/datetime.html#id1 for date format strings)
 Date Format =
+Date Language =
 Inflow or Outflow Indicator =
 # Output file formatting
 Output Columns = Date,Payee,Category,Memo,Outflow,Inflow


### PR DESCRIPTION
If source date format is like '16 Oktober 2019' and 'Oktober' is spelled in another language then your current LC_TIME, then you need to change date format language.
Valid inputs are 'sv_SE.UTF-8', 'en_US.UTF-8' or whatever your operating system understand as LC_TIME variable.