### PR TITLE
Fix csvreader line numbering.

### DIFF
--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -445,7 +445,7 @@ class B2YBank(object):
             # make each row of our new transaction file
             for line, row in enumerate(transaction_reader):
                 # skip header & footer rows
-                if header_rows < line <= (row_count - footer_rows):
+                if header_rows <= line <= (row_count - footer_rows):
                     # skip blank rows
                     if len(row) == 0:
                         continue

--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -443,8 +443,7 @@ class B2YBank(object):
 
         with EncodingCsvReader(file_path, delimiter=delim) as transaction_reader:
             # make each row of our new transaction file
-            for row in transaction_reader:
-                line = transaction_reader.line_num
+            for line, row in enumerate(transaction_reader):
                 # skip header & footer rows
                 if header_rows < line <= (row_count - footer_rows):
                     # skip blank rows


### PR DESCRIPTION
**New Pull Request**
Noticed (after some debugging...) while implementing #328 that only 2 lines would get converter and found an error in the line numbering.

**Description**
line_num is not equals the rows of the csv. It basically counts \n characters. This fails, when entries contain newlines.
See https://docs.python.org/3.7/library/csv.html#csv.csvreader.line_num

**Changes**
It's a simple and small change, since the csvreader is already used in a for loop. Instead of asking the underlying stream for a line number, just count the loops (the same approach as the lines above for getting the total number of rows).
This fixes especially any issues with line numbering an headers.

