### PR TITLE
Add encoding support via chardet.

### DIFF
--- a/bank2ynab.py
+++ b/bank2ynab.py
@@ -25,6 +25,7 @@ import re
 from datetime import datetime
 import logging
 import configparser
+import chardet
 
 # API testing stuff
 import requests
@@ -90,6 +91,17 @@ def detect_encoding(filepath):
     :param filepath: string path to a given file
     :return: encoding alias that can be used with open()
     """
+    # First try to guess the encoding with chardet. Take it if the
+    # confidence is >50% (randomly chosen)
+    with open(filepath, 'rb') as f:
+        file_content = f.read()
+        rslt = chardet.detect(file_content)
+        confidence, encoding = rslt['confidence'], rslt['encoding']
+        if confidence > 0.5:
+            logging.info("Using encoding {} with confidence {}".format(encoding, confidence))
+            return encoding
+        
+
     # because some encodings will happily encode anything even if wrong,
     # keeping the most common near the top should make it more likely that
     # we're doing the right thing.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.20.0
+chardet>=3.0.2


### PR DESCRIPTION
**New Pull Request**
Since chardet is already an indirect dependency (from requests), it can
be easily added for detection. Leaving in the old method as fallback, in
case the confidence is below 50%

**Description**
I made this change to my sourcecode since the encoding was way off and produced all kinds of artifacts. It's passing the tests, and works for all of my bank accounts in German. They ususally get a confidence level between 0.7 and 0.9

I also added chardet as explicit dependency in requirements.txt

[**chardet**](https://chardet.readthedocs.io/en/latest/index.html)
It's originally code from Mozilla, based on an [interesting paper,](https://www-archive.mozilla.org/projects/intl/universalcharsetdetection) with some fancy algorithms. Since it's used by requests I wouldn't worry too much about the added dependency