### PR TITLE
fix: Nordea SE export formats

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -584,14 +584,27 @@ Header Rows = 1
 # "Bokföringsdatum";"Transaktionsdatum";"Transaktionstyp";"Meddelande";"Belopp";"Kontonummer";"Kontonamn";"";"Saldo";"Tillgängligt belopp"
 Input Columns = skip,Date,skip,Payee,Inflow,skip,skip,skip,skip,skip
 
-[SE Nordea]
-# source: Issue #92
-# export.csv
-Source Filename Pattern = export
-Source CSV Delimiter = ,
+[SE Nordea - internetbanken.privat.nordea.se]
+# The "old" format, see https://github.com/bank2ynab/bank2ynab/issues/338
+# The default export name is export.csv, but until https://github.com/bank2ynab/bank2ynab/issues/339
+# is fixed we'll also support renaming it to nordea-export.csv so it's atleast usable.
+Source Filename Pattern = (nordea-)?export
+Use Regex for Filename = True
 Header Rows = 1
-Footer Rows = 1
-Input Columns = Date,Payee,Outflow,Inflow,Running Balance
+Footer Rows = 2
+# Datum,Transaktion,Kategori,Belopp,Saldo
+Input Columns = Date,Payee,skip,Inflow,skip
+Date Format = %Y-%m-%d
+
+[SE Nordea - netbank.nordea.se]
+# The "new" format, see https://github.com/bank2ynab/bank2ynab/issues/338
+# Example: Checking account 990101-1234 - 2020.05.05 16.30
+# Example: Savings 1234 56 7890 - 2020.05.05 17.10
+Source Filename Pattern = .* - [0-9]{4}.[0-9]{2}.[0-9]{2} [0-9]{2}.[0-9]{2}
+Use Regex for Filename = True
+Source CSV Delimiter = ;
+# Bokföringsdag;Belopp;Avsändare;Mottagare;Namn;Rubrik;Saldo;Valuta
+Input Columns = Date,Inflow,skip,skip,skip,Payee,skip,skip
 Date Format = %Y-%m-%d
 
 [SE SEB Skandinaviska Enskilda Banken]


### PR DESCRIPTION
Fixes #338

**Description**
Fixes the export format for Swedish Nordea's old site and adds support for the format exported by the new site.

**Note**
Until #339 is fixed any Nordea SE files exported from the old site with the name of `export.csv` aren't going to work since they'll be overwritten by another (failing) config to be empty files. As a temporary workaround you can rename these to `nordea-export.csv` and they'll be parsed and fixed without conflict.
This is not an issue for exports from the new site, since they're named according to the account you export from and includes the date and time.