### PR TITLE
Change date format and columns for [AU ING]

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -107,8 +107,8 @@ Header Rows = 1
 # The input csv uses 2 seperate columns, but has positive values
 # for the inflows and negative values for the outflows
 # The conversion will take those negative inflows and convert them to outflows
-Input Columns = Date,skip,Payee,Inflow,Inflow
-Date Format = %d/%m/%y
+Input Columns = Date,Memo,Inflow,Inflow,skip
+Date Format = %d/%m/%Y
 
 [AU National Australia Bank]
 # TransactionExport.csv


### PR DESCRIPTION
Fixes #356 
Date Format = %d/%m/%Y 
Input columns = Date,Memo,Inflow,Inflow,skip


**New Pull Request**

**Reference Issue:**
#356 

**Description**
Update to account for four digit year and adjusted input columns according to user feedback. Credit to @zirophyz for the contribution.