### PR TITLE
Update US Schwab with default filename pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ Here is a list of the banks and their formats that we already support. Note that
 1. US BB&T
 1. US Chase Credit Card 2017
 1. US Chase Credit Card 2019
-1. US Schwab
+1. US Schwab Checking
+1. US Schwab Savings
 1. US TB Bank
 1. US USAA
 <!--AUTO BANK UPDATE END-->

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -770,11 +770,17 @@ Use Regex for Filename = True
 Input Columns = skip,Date,skip,Memo,skip,skip,Inflow
 Date Format = %m/%d/%Y
 
-[US Schwab]
+[US Schwab Checking]
 # source: Issue #122
-Source Filename Pattern = unknown!
-# The default filename is unknown! Please submit an issue if you know the name! See details here:
-# https://github.com/bank2ynab/bank2ynab/wiki/MissingDefaultFilename
+Source Filename Pattern = Source Filename Pattern = XXXXXX[0-9]{6}_(Checking)_Transactions_[0-9]{8}-[0-9]{6}
+Header Rows = 3
+Footer Rows = 0
+Input Columns = Date,skip,skip,Payee,Outflow,Inflow,skip
+Date Format = %m/%d/%Y
+
+[US Schwab Savings]
+# source: Issue #122
+Source Filename Pattern = Source Filename Pattern = XXXXXX[0-9]{6}_(Savings)_Transactions_[0-9]{8}-[0-9]{6}
 Header Rows = 3
 Footer Rows = 0
 Input Columns = Date,skip,skip,Payee,Outflow,Inflow,skip


### PR DESCRIPTION
Fixes #122


**New Pull Request**

**Reference Issue:**
#122 

**Description**
Add filename pattern for [US Schwab] and split into separate Checking and Savings accounts.
