### PR TITLE
Adding possibility of lower/upper case extension

### DIFF
--- a/bank2ynab/bank_process.py
+++ b/bank2ynab/bank_process.py
@@ -77,7 +77,7 @@ class B2YBank(object):
                 files = [
                     join(path, f)
                     for f in directory_list
-                    if f.endswith(ext)
+                    if f.endswith(ext) or f.endswith(ext.lower()) or f.endswith(ext.upper())
                     if f.startswith(file_pattern)
                     if prefix not in f
                 ]


### PR DESCRIPTION
I wanted to import an export from Commerzbank which got downloaded as ".csv".
The default file extension is ".CSV", which caused the problem that the file was not found or was ignored.

How about searching for the extension in lower case as well as upper case?
In my commit the lower and upper function is used to better recognize the file extension.