### PR TITLE
Add Rabobank creditcard format

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -533,6 +533,15 @@ Source Filename Pattern = CSV_A_20[0-9]{6}_[0-9]{6}
 Input Columns = skip,skip,skip,skip,Date,skip,Inflow,skip,skip,Payee,skip,skip,skip,skip,skip,skip,skip,skip,skip,Memo,skip,skip,skip,skip,skip,skip
 Date Format = %Y-%m-%d
 
+[NL Rabobank Credit Card]
+# CSV_CC_20201026_154139.csv
+Use Regex for Filename = True
+Source Filename Pattern = CSV_CC_20[0-9]{6}_[0-9]{6}
+# Tegenrekening IBAN,"Munt","Creditcard Nummer","Productnaam","Creditcard Regel1","Creditcard Regel2","Transactiereferentie","Datum","Bedrag","Omschrijving","Oorspr bedrag","Oorspr munt","Koers"
+Input Columns = skip,skip,skip,skip,skip,skip,skip,Date,Inflow,Payee,skip,skip,skip
+Date Format = %Y%m%d
+
+
 [NO DNB]
 # source: survey response #12
 # maanedtransaksjonliste-[a-z]{3}.csv


### PR DESCRIPTION
**Reference Issue:**
None


**Description**
Adds support for the creditcard format used by the Dutch bank Rabobank
