### PR TITLE
Adds support for new NL ING format

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -498,18 +498,6 @@ Use Regex for Filename = True
 Source Filename Pattern = NL[0-9]{2}INGB[0-9]*_[0-9]{2}-[0-9]{2}-[0-9]{4}_[0-9]{2}-[0-9]{2}-[0-9]{4}
 Header Rows = 1
 Footer Rows = 0
-# Datum,"Naam / Omschrijving","Rekening","Tegenrekening","Code","Af Bij","Bedrag (EUR)","MutatieSoort","Mededelingen"
-Input Columns = Date,Payee,skip,skip,skip,CDFlag,Inflow,skip,Memo
-Date Format = %Y%m%d
-Inflow or Outflow Indicator = 5,Bij,Af
-
-[NL ING Checking 2020 2]
-# source: survey response #53, 20200116 
-# NL04INGB0704279991_01-01-2019_11-01-2020.csv
-Use Regex for Filename = True
-Source Filename Pattern = NL[0-9]{2}INGB[0-9]*_[0-9]{2}-[0-9]{2}-[0-9]{4}_[0-9]{2}-[0-9]{2}-[0-9]{4}
-Header Rows = 1
-Footer Rows = 0
 Source CSV Delimiter = ;
 # Datum,"Naam / Omschrijving","Rekening","Tegenrekening","Code","Af Bij","Bedrag (EUR)","MutatieSoort","Mededelingen"
 Input Columns = Date,Payee,skip,skip,skip,CDFlag,Inflow,skip,Memo

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -503,6 +503,19 @@ Input Columns = Date,Payee,skip,skip,skip,CDFlag,Inflow,skip,Memo
 Date Format = %Y%m%d
 Inflow or Outflow Indicator = 5,Bij,Af
 
+[NL ING Checking 2020 2]
+# source: survey response #53, 20200116 
+# NL04INGB0704279991_01-01-2019_11-01-2020.csv
+Use Regex for Filename = True
+Source Filename Pattern = NL[0-9]{2}INGB[0-9]*_[0-9]{2}-[0-9]{2}-[0-9]{4}_[0-9]{2}-[0-9]{2}-[0-9]{4}
+Header Rows = 1
+Footer Rows = 0
+Source CSV Delimiter = ;
+# Datum,"Naam / Omschrijving","Rekening","Tegenrekening","Code","Af Bij","Bedrag (EUR)","MutatieSoort","Mededelingen"
+Input Columns = Date,Payee,skip,skip,skip,CDFlag,Inflow,skip,Memo
+Date Format = %Y%m%d
+Inflow or Outflow Indicator = 5,Bij,Af
+
 [NL KNAB]
 # Knab transactieoverzicht betaalrekening NL12KNAB0123456789 - 2020-08-10 - 2020-09-10.csv
 Use Regex for Filename = True


### PR DESCRIPTION
**Reference Issue:**
Fixes #365 


**Description**
Apparently the Dutch bank ING added a new format that changes the delimiter to a semicolon and adds two new (useless) fields.

*Explain the changes that this pull request makes*
This adds a new variant of the NL ING checking 2020 entry to support the semicolon-delimited version. The old version is also still available to download on the ING website so I left that in as well.
