### PR TITLE
Add [SG OCBC Bank Credit Card]

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Here is a list of the banks and their formats that we already support. Note that
 1. SE Swedbank 2019
 1. SE Swedbank 2020
 1. SG OCBC Bank
+1. SG OCBC Bank Credit Card
 1. SG POSB savings
 1. SK Tatra Banka
 1. SK VUB

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -683,6 +683,15 @@ Input Columns = Date,skip,Memo,Outflow,Inflow,Payee
 Date Format = %d/%m/%Y
 Plugin = OCBC_Bank_SG
 
+[SG OCBC Bank Credit Card]
+Use Regex For Filename = True
+Source Filename Pattern = TransactionHistory_\d{4}\d{2}\d{2}\d{6}
+Header Rows = 4
+Footer Rows = 2
+Input Columns = Date,Memo,Outflow,Inflow
+Date Format = %d/%m/%Y
+Plugin = OCBC_Bank_SG
+
 [SG POSB savings]
 # source: survey response #23
 Source Filename Pattern = [0-9a-z]{32}.[A-Z][0-9]{15}


### PR DESCRIPTION
Fixes #372 (Partially. No way to differentiate between current account and credit card file as they have the same filename.)


