### PR TITLE
Add support for [CO] Bancolombia

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Here is a list of the banks and their formats that we already support. Note that
 1. CA TD Canada Trust, checking+Visa
 1. CH ZKB Erweiterte Suche
 1. CH ZKB Finanzassistent-Chronik
+1. CO Bancolombia
 1. CZ AirBank checking and savings
 1. CZ Ceska Sporitelna
 1. CZ Raiffeisen bank

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -187,7 +187,7 @@ Source Filename Extension = .txt
 Use Regex for Filename = True
 Source CSV Delimiter = \t
 Source Has Column Headers = True
-Input Columns = Date,Payee,Memo,Inflow
+Input Columns = Date,skip,skip,Memo,skip,Inflow
 
 [CZ AirBank checking and savings]
 Use Regex For Filename = True

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -188,6 +188,8 @@ Use Regex for Filename = True
 Source CSV Delimiter = \t
 Source Has Column Headers = True
 Input Columns = Date,skip,skip,Memo,skip,Inflow
+Date Format = %Y/%m/%d
+
 
 [CZ AirBank checking and savings]
 Use Regex For Filename = True

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -392,8 +392,8 @@ Input Columns = skip,Date,Payee,skip,skip,Outflow,Inflow,skip,skip,skip,skip
 Date Format = %d/%m/%Y
 
 [IE Bank of Ireland]
-# TransactionExport.csv
-Source Filename Pattern = TransactionExport
+Use Regex For Filename = True
+Source Filename Pattern = [a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}
 Input Columns = Date,Payee,Outflow,Inflow,skip
 Date Format = %d/%m/%Y
 

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -13,7 +13,7 @@ Source CSV Delimiter = ,
 Header Rows = 1
 Footer Rows = 0
 Input Columns = Date,Payee,Outflow,Inflow,Running Balance
-# (see https://docs.python.org/2/library/datetime.html#id1 for date format strings)
+# (see https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes for date format strings)
 Date Format =
 Inflow or Outflow Indicator =
 # Output file formatting

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -185,7 +185,7 @@ Source CSV Delimiter = ;
 Source Filename Pattern = [0-9]{3}-[0-9]{6}-[0-9]{2}_[0-9]{3}
 Source Filename Extension = .txt
 Use Regex for Filename = True
-Source CSV Delimiter = ,
+Source CSV Delimiter = \t
 Source Has Column Headers = True
 Input Columns = Date,Payee,Memo,Inflow
 

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -181,6 +181,14 @@ Input Columns = Date,Category,skip,Inflow,Memo,Payee,skip
 Date Format = %Y-%m-%d
 Source CSV Delimiter = ;
 
+[CO Bancolombia]
+Source Filename Pattern = [0-9]{3}-[0-9]{6}-[0-9]{2}_[0-9]{3}
+Source Filename Extension = .txt
+Use Regex for Filename = True
+Source CSV Delimiter = ,
+Source Has Column Headers = True
+Input Columns = Date,Payee,Memo,Inflow
+
 [CZ AirBank checking and savings]
 Use Regex For Filename = True
 Source Filename Pattern = airbank_[0-9]{10}_[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}


### PR DESCRIPTION
**Reference Issue:**
Fixes #106 

**Description**
Adds bank format information provided by @ricardopolo

```
[CO Bancolombia]
Source Filename Pattern = [0-9]{3}-[0-9]{6}-[0-9]{2}_[0-9]{3}
Source Filename Extension = .txt
Use Regex for Filename = True
Source CSV Delimiter = ,
Source Has Column Headers = True
Input Columns = Date,Payee,Memo,Inflow
```