### PR TITLE
Feature/389 toggle for saving bank account selection

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -18,7 +18,7 @@ jobs:
         run: pip install black flake8
 
       - name: Run linters
-        uses: wearerequired/lint-action@feature/pull_request_target
+        uses: wearerequired/lint-action
         with:
           github_token: ${{ secrets.github_token }}
           auto_fix: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -18,7 +18,7 @@ jobs:
         run: pip install black flake8
 
       - name: Run linters
-        uses: wearerequired/lint-action
+        uses: wearerequired/lint-action@v1.9.0
         with:
           github_token: ${{ secrets.github_token }}
           auto_fix: ${{ github.event_name == 'pull_request' }}

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -25,6 +25,7 @@ Delete Source File = True
 # Plugins
 Plugin =
 # YNAB API Stuff - don't modify values here, modify in user_configuration.conf
+Save YNAB Account = True
 YNAB API Access Token =
 YNAB Account ID =
 

--- a/bank2ynab/b2y_utilities.py
+++ b/bank2ynab/b2y_utilities.py
@@ -8,7 +8,7 @@ import csv
 
 # Generic utilities
 def get_configs():
-    """ Retrieve all configuration parameters."""
+    """Retrieve all configuration parameters."""
     # TODO - fix path for these
     path = os.path.realpath(__file__)
     parent_dir = os.path.dirname(path)
@@ -313,7 +313,7 @@ def detect_encoding(filepath):
 
 # classes dealing with input and output charsets
 class EncodingFileContext(object):
-    """ ContextManager class for common operations on files"""
+    """ContextManager class for common operations on files"""
 
     def __init__(self, file_path, **kwds):
         self.file_path = os.path.abspath(file_path)
@@ -335,7 +335,7 @@ class EncodingFileContext(object):
 
 
 class EncodingCsvReader(EncodingFileContext):
-    """ context manager returning a csv.Reader-compatible object"""
+    """context manager returning a csv.Reader-compatible object"""
 
     def __enter__(self):
         encoding = detect_encoding(self.file_path)

--- a/bank2ynab/bank_process.py
+++ b/bank2ynab/bank_process.py
@@ -331,7 +331,7 @@ class B2YBank(object):
 
 
 def build_bank(bank_config):
-    """ Factory method loading the correct class for a given configuration. """
+    """Factory method loading the correct class for a given configuration."""
     plugin_module = bank_config.get("plugin", None)
     if plugin_module:
         p_mod = importlib.import_module("plugins.{}".format(plugin_module))
@@ -362,7 +362,7 @@ class Bank2Ynab(object):
             self.banks.append(bank_object)
 
     def run(self):
-        """ Main program flow """
+        """Main program flow"""
         # initialize variables for summary:
         files_processed = 0
         # process account for each config file

--- a/bank2ynab/plugins/OCBC_Bank_SG.py
+++ b/bank2ynab/plugins/OCBC_Bank_SG.py
@@ -4,7 +4,7 @@ from bank_process import B2YBank
 
 
 class OCBC_Bank_SG(B2YBank):
-    """ Example subclass used for testing the plugin system."""
+    """Example subclass used for testing the plugin system."""
 
     def __init__(self, config_object):
         """

--- a/bank2ynab/plugins/null.py
+++ b/bank2ynab/plugins/null.py
@@ -12,7 +12,7 @@ from bank_process import B2YBank
 
 
 class NullBank(B2YBank):
-    """ Example subclass used for testing the plugin system."""
+    """Example subclass used for testing the plugin system."""
 
     def __init__(self, config_object):
         """

--- a/bank2ynab/ynab_api.py
+++ b/bank2ynab/ynab_api.py
@@ -296,7 +296,11 @@ class YNAB_API(object):  # in progress (2)
             if save_ac_toggle is True:
                 self.save_account_selection(bank, budget_id, account_id)
             else:
-                logging.info("Saving default YNAB account is disabled for {} - account match not saved.".format(bank))
+                logging.info(
+                    "Saving default YNAB account is disabled for {} - account match not saved.".format(
+                        bank
+                    )
+                )
         return budget_id, account_id
 
     def save_account_selection(self, bank, budget_id, account_id):

--- a/bank2ynab/ynab_api.py
+++ b/bank2ynab/ynab_api.py
@@ -290,7 +290,13 @@ class YNAB_API(object):  # in progress (2)
             msg = instruction.format("account", bank, "an account")
             account_id = b2y_utilities.option_selection(account_ids, msg)
             # save account selection for bank
-            self.save_account_selection(bank, budget_id, account_id)
+            save_ac_toggle = b2y_utilities.get_config_line(
+                self.config, bank, ["Save YNAB Account", True, ""]
+            )
+            if save_ac_toggle:
+                self.save_account_selection(bank, budget_id, account_id)
+            else:
+                logging.info("Saving default YNAB account is disabled for {} - account match not saved.".format(bank))
         return budget_id, account_id
 
     def save_account_selection(self, bank, budget_id, account_id):

--- a/bank2ynab/ynab_api.py
+++ b/bank2ynab/ynab_api.py
@@ -293,7 +293,7 @@ class YNAB_API(object):  # in progress (2)
             save_ac_toggle = b2y_utilities.get_config_line(
                 self.config, bank, ["Save YNAB Account", True, ""]
             )
-            if save_ac_toggle:
+            if save_ac_toggle is True:
                 self.save_account_selection(bank, budget_id, account_id)
             else:
                 logging.info("Saving default YNAB account is disabled for {} - account match not saved.".format(bank))

--- a/test-data/test.conf
+++ b/test-data/test.conf
@@ -88,6 +88,9 @@ Date Format = %d.%m.%Y
 [test_api_existing_bank]
 YNAB Account ID = Test Budget ID 1||Test Account ID
 
+[test_api_existing_bank_2]
+YNAB Account ID = Test Budget ID 2||ID #2
+
 [test_jlp_card]
 Use Regex For Filename = True
 Input Columns = Date,Payee,Outflow,skip

--- a/test-data/test.conf
+++ b/test-data/test.conf
@@ -5,6 +5,7 @@
 Source Path = test-data
 Delete Source File = False
 YNAB API Access Token = ynab
+Save YNAB Account = True
 
 [test_num_files]
 Source Filename Pattern = test_raiffeisen_

--- a/test/test_B2YBank.py
+++ b/test/test_B2YBank.py
@@ -25,14 +25,14 @@ class TestB2YBank(TestCase):
         pass
 
     def test_init_and_name(self):
-        """ Check parameters are correctly stored in the object."""
+        """Check parameters are correctly stored in the object."""
         self.b = B2YBank(self.defaults)
         cfe = copy(self.defaults)
         self.assertEqual(self.b.config, cfe)
         self.assertEqual("DEFAULT", self.b.name)
 
     def test_get_files(self):
-        """ Test it's finding the right amount of files"""
+        """Test it's finding the right amount of files"""
         # if you need more tests, add sections to test.conf & specify them here
         for section_name, num_files in [
             ("test_num_files", 2),
@@ -53,7 +53,7 @@ class TestB2YBank(TestCase):
             self.assertEqual(len(files), num_files)
 
     def test_read_data(self):
-        """ Test that the right number of rows are read from the test files """
+        """Test that the right number of rows are read from the test files"""
         # if you need more tests, add sections to test.conf & specify them here
         for section_name, num_records, fpath in [
             ("test_record_i18n", 74, "test_raiffeisen_01.csv"),
@@ -101,7 +101,7 @@ class TestB2YBank(TestCase):
         self.assertRaises(ImportError, build_bank, missingconf)
 
     def test_fix_row(self):
-        """ Check output row is the same across different formats """
+        """Check output row is the same across different formats"""
         # todo: something where the row format is invalid
         # if you need more tests, add sections to test.conf & specify them here
         for section_name in [
@@ -144,7 +144,7 @@ class TestB2YBank(TestCase):
                     self.assertCountEqual(expected_row, result_row)
 
     def test_valid_row(self):
-        """ Test making sure row has an outflow or an inflow """
+        """Test making sure row has an outflow or an inflow"""
         config = fix_conf_params(self.cp, "test_row_format_default")
         b = B2YBank(config)
 
@@ -160,7 +160,7 @@ class TestB2YBank(TestCase):
             self.assertEqual(is_valid, row_validity)
 
     def test_clean_monetary_values(self):
-        """ Test cleaning of outflow and inflow of unneeded characters """
+        """Test cleaning of outflow and inflow of unneeded characters"""
         config = fix_conf_params(self.cp, "test_row_format_default")
         b = B2YBank(config)
 
@@ -178,7 +178,7 @@ class TestB2YBank(TestCase):
             self.assertCountEqual(expected_row, result_row)
 
     def test_auto_memo(self):
-        """ Test auto-filling empty memo field with payee data """
+        """Test auto-filling empty memo field with payee data"""
         config = fix_conf_params(self.cp, "test_row_format_default")
         b = B2YBank(config)
         memo_index = b.config["output_columns"].index("Memo")
@@ -193,7 +193,7 @@ class TestB2YBank(TestCase):
             self.assertEqual(test_memo, new_memo)
 
     def test_fix_outflow(self):
-        """ Test conversion of negative Inflow into Outflow """
+        """Test conversion of negative Inflow into Outflow"""
         config = fix_conf_params(self.cp, "test_row_format_default")
         b = B2YBank(config)
 
@@ -215,7 +215,7 @@ class TestB2YBank(TestCase):
             self.assertCountEqual(expected_row, result_row)
 
     def test_fix_inflow(self):
-        """ Test conversion of positive Outflow into Inflow """
+        """Test conversion of positive Outflow into Inflow"""
         config = fix_conf_params(self.cp, "test_row_format_default")
         b = B2YBank(config)
 

--- a/test/test_JLP_Card.py
+++ b/test/test_JLP_Card.py
@@ -18,7 +18,7 @@ class TestJLP_Card_UK(TestCase):
         pass
 
     def test_read_data(self):
-        """ Test that the right number of rows are read and values. """
+        """Test that the right number of rows are read and values."""
         (section_name, num_records, fpath) = (
             "test_jlp_card",
             11,

--- a/test/test_YNAB_API.py
+++ b/test/test_YNAB_API.py
@@ -407,7 +407,7 @@ class Test_YNAB_API(TestCase):
         test_class = YNAB_API(self.cp)
         test_banks = [
             ("test_api_existing_bank", "Test Budget ID 1", "Test Account ID"),
-            ("New Bank", "Test Budget ID 2", "ID #2"),
+            ("test_api_existing_bank_2", "Test Budget ID 2", "ID #2"),
         ]
         test_class.config_path = self.TEMPCONFPATH
         test_class.config = configparser.RawConfigParser()

--- a/test/test_YNAB_API.py
+++ b/test/test_YNAB_API.py
@@ -35,7 +35,7 @@ class Test_YNAB_API(TestCase):
             os.remove(self.TEMPCONFPATH)
 
     def test_init_and_name(self):  # todo
-        """ Check parameters are correctly stored in the API object."""
+        """Check parameters are correctly stored in the API object."""
         """
         self.test_class = YNAB_API(self.defaults)
         cfe = copy(self.defaults)


### PR DESCRIPTION
**Reference Issue:**
Fixes #389

**Description**
Allows disabling YNAB account-pairing on a per-bank basis in `user_configuration.conf` by setting the new `Save YNAB Account` flag to `False`. 

*Explain the changes that this pull request makes*
- Added `Save YNAB Account = True` to `bank2ynab.conf` `DEFAULT` section. 
- Add handling for the `Save YNAB Account` config flag to `ynab_api.py`