### PR TITLE
Fixing SE Länsförsäkringar checking for two digit year format.

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -643,6 +643,7 @@ Source CSV Delimiter = ;
 Header Rows = 1
 # "Bokföringsdatum";"Transaktionsdatum";"Transaktionstyp";"Meddelande";"Belopp";"Kontonummer";"Kontonamn";"";"Saldo";"Tillgängligt belopp"
 Input Columns = skip,Date,skip,Payee,Inflow,skip,skip,skip,skip,skip
+Date Format = %d/%m/%y
 
 [SE Nordea - internetbanken.privat.nordea.se]
 # The "old" format, see https://github.com/bank2ynab/bank2ynab/issues/338


### PR DESCRIPTION
**New Pull Request**

**Reference Issue:**
Fixes #397

**Description**
The latest csv files from Länsförsäkringar contain two-digit year numbers, and that is not recognized by the default. The date format has to be explicitely set in the relevant section in the conf file.
