### PR TITLE
Add configuration for Crypto.com card CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Here is a list of the banks and their formats that we already support. Note that
 1. CH ZKB Erweiterte Suche
 1. CH ZKB Finanzassistent-Chronik
 1. CO Bancolombia
+1. Crypto.com Card
 1. CZ AirBank checking and savings
 1. CZ Ceska Sporitelna
 1. CZ Raiffeisen bank

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -216,6 +216,15 @@ Header Rows = 1
 Input Columns = Date,skip,skip,Memo,skip,Inflow
 Date Format = %Y/%m/%d
 
+[Crypto.com]
+# card_transactions_record_20220107_101840
+Source Filename Pattern = card_transactions_record_[0-9]{8}_[0-9]{6}
+Source Filename Extension = .csv
+Use Regex for Filename = True
+Header Rows = 1
+Input Columns = skip,skip,Date,skip,Payee,Inflow,skip,skip,skip,skip
+Date Format = %Y-%m-%d %H:%M:%S
+
 [CZ AirBank checking and savings]
 Use Regex For Filename = True
 Source Filename Pattern = airbank_[0-9]{10}_[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}


### PR DESCRIPTION
**New Pull Request**

**Reference Issue:**
No issue open yet

**Description**
Adds support for the Crypto.com output based on exporting some sample files.

File looks like this:

```
Timestamp (UTC),Transaction Description,Currency,Amount,To Currency,To Amount,Native Currency,Native Amount,Native Amount (in USD),Transaction Kind
2022-01-07 09:12:31,You Need A Budget,USD,-98.99,,,EUR,-87.73,-99.5546152341,
```
