### PR TITLE
Update Crypto.com column order

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -228,7 +228,7 @@ Source Filename Pattern = card_transactions_record_[0-9]{8}_[0-9]{6}
 Source Filename Extension = .csv
 Use Regex for Filename = True
 Header Rows = 1
-Input Columns = skip,skip,Date,skip,Payee,Inflow,skip,skip,skip,skip
+Input Columns = Date,Payee,skip,skip,skip,skip,skip,Inflow,skip,skip
 Date Format = %Y-%m-%d %H:%M:%S
 
 [CZ AirBank checking and savings]


### PR DESCRIPTION
**Reference Issue:**
Fix for https://github.com/bank2ynab/bank2ynab/pull/410

Seemingly the column order has changed somehow, this is the correct order, example transactions:


```
Timestamp (UTC),Transaction Description,Currency,Amount,To Currency,To Amount,Native Currency,Native Amount,Native Amount (in USD),Transaction Kind
2022-01-07 09:12:31,You Need A Budget,USD,-98.99,,,EUR,-87.73,-99.5546152341,
2022-01-07 09:07:59,Google,EUR,-222.8,,,EUR,-222.8,-252.829913076,
2022-01-07 08:55:51,EUR -> EUR,EUR,750.0,EUR,750.0,EUR,750.0,851.0881275,
```
