### PR TITLE
Plugin ParseFromMemo: Leave bank name as default

### DIFF
--- a/bank2ynab/plugins/parse_from_memo.py
+++ b/bank2ynab/plugins/parse_from_memo.py
@@ -29,7 +29,6 @@ class ParseFromMemo(BankHandler):
         :param config_object: a dictionary of conf parameters
         """
         super(ParseFromMemo, self).__init__(config_object)
-        self.name = "ParseFromMemo"
 
         # Parsers from the Config, skipping blank rows
         memo_parsers = list(filter(len, self.config_dict.get("plugin_args", [])))


### PR DESCRIPTION
Now that `BankHandler.name` is used to decide which account to map to, overriding the name causes problems.

Having the plugin not mutate the name means it falls back to the bank name from the config file and avoids a configparser.NoSectionError when the YNAB upload starts.

Example without this change (note the bank name is **ParseFromMemo** not `BE KBC checking`):

```bash
No YNAB account for transactions from ParseFromMemo set!
Pick an account (range 1 - 2): 1
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/pezcuckow/Git/bank2ynab/bank2ynab/__main__.py", line 64, in <module>
    api.run(bank_transaction_dict)
  File "/Users/pezcuckow/Git/bank2ynab/bank2ynab/ynab_api.py", line 52, in run
    self.save_account_mappings(bank_account_mapping)
  File "/Users/pezcuckow/Git/bank2ynab/bank2ynab/ynab_api.py", line 99, in save_account_mappings
    save_ac_toggle = self.config_handler.get_config_line_boo(
  File "/Users/pezcuckow/Git/bank2ynab/bank2ynab/config_handler.py", line 173, in get_config_line_boo
    return self.config.getboolean(section_name, param)
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/configparser.py", line 828, in getboolean
    return self._get_conv(section, option, self._convert_to_boolean,
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/configparser.py", line 808, in _get_conv
    return self._get(section, conv, option, raw=raw, vars=vars,
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/configparser.py", line 803, in _get
    return conv(self.get(section, option, **kwargs))
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/configparser.py", line 781, in get
    d = self._unify_values(section, vars)
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/configparser.py", line 1152, in _unify_values
    raise NoSectionError(section) from None
configparser.NoSectionError: No section: 'ParseFromMemo'
```
