### PR TITLE
fix(bank2ynab.conf): skip new columns for Danske

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -440,9 +440,9 @@ Date Format = %d-%m-%Y
 # Accountname-1234567890-12345678.csv
 Source Filename Pattern = [\S]*-\d{10}-\d{8}.csv
 Use Regex For Filename = True
-# "Dato";"Tekst";"Bel�b";"Saldo";"Status";"Afstemt"
+# "Dato";"Kategori";"Underkategori";"Tekst";"Bel�b";"Saldo";"Status";"Afstemt"
 Source CSV Delimiter = ;
-Input Columns = Date,Payee,Inflow,Running Balance,skip,skip
+Input Columns = Date,Payee,skip,skip,Inflow,Running Balance,skip,skip
 Date Format = %d.%m.%Y
 
 [DK Jyske Bank VISA]


### PR DESCRIPTION
**New Pull Request**

**Reference Issue:**
No existing issue.


**Description**
In the output data for Danske Bank accounts, there is now two new columns, "Kategori" and "Underkatagori".
I've updated the configuration to skip both of these values, so that it can parse the csv and map to the correct columns.