### PR TITLE
Allow accented characters in strings (modify clean_strings function)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,13 @@ Here is a list of the banks and their formats that we already support. Note that
 1. AT Raiffeisen Bank 2018
 1. AT Raiffeisen Bank RCM
 1. AT Raiffeisen Bank 2019 checking
+1. AT Raiffeisen Bank 2021 checking
 1. AT Raiffeisen VISA
 1. AU ANZ
 1. AU ING
 1. AU National Australia Bank
+1. BE BNP Paribas Fortis old
+1. BE BNP Paribas Fortis Export
 1. BE KBC checking
 1. BE KBC credit
 1. BE Keytrade Bank
@@ -124,7 +127,7 @@ Here is a list of the banks and their formats that we already support. Note that
 1. CH ZKB Erweiterte Suche
 1. CH ZKB Finanzassistent-Chronik
 1. CO Bancolombia
-1. Crypto.com Card
+1. Crypto.com
 1. CZ AirBank checking and savings
 1. CZ Ceska Sporitelna
 1. CZ Raiffeisen bank
@@ -142,7 +145,6 @@ Here is a list of the banks and their formats that we already support. Note that
 1. DE Ostseesparkasse Rostock checking
 1. DE Ostseesparkasse Rostock credit card
 1. DE Sparkasse Rhein-Neckar-Nord
-1. DE Landesbank Berlin Amazon Kreditkarten-Banking
 1. DE Sparkasse Südholstein
 1. DK Bankernes EDB Central
 1. DK Danske Bank
@@ -196,7 +198,8 @@ Here is a list of the banks and their formats that we already support. Note that
 1. UK Barclaycard credit card
 1. UK Barclaycard Business Credit Card
 1. UK first direct checking
-1. UK John Lewis Partnership Card
+1. UK John Lewis Partnership Card (Pre-2022 Format)
+1. UK John Lewis Partnership Card (NewDay Format)
 1. US Bank of America
 1. US Bank of America Credit Card
 1. US BB&T

--- a/bank2ynab/dataframe_handler.py
+++ b/bank2ynab/dataframe_handler.py
@@ -426,7 +426,7 @@ def clean_strings(string_series: pd.Series) -> pd.Series:
     modified_string_series = modified_string_series.str.title()
     # remove non-alphanumeric
     modified_string_series = modified_string_series.replace(
-        "[^a-zA-Z0-9 ]", " ", regex=True
+        r"[^\w\d ]", " ", regex=True
     )
     # remove newline characters
     modified_string_series = modified_string_series.str.replace(

--- a/test/unit/test_dataframe_handler.py
+++ b/test/unit/test_dataframe_handler.py
@@ -333,7 +333,10 @@ class TestDataframeHandler(TestCase):
             [r"Non alphanumeric \ ! @", "Non Alphanumeric"],
             ["RanDom CAPITAL letters", "Random Capital Letters"],
             ["New Line\nIn The String", "New Line In The String"],
-            ["Ðön't rēmove ácçeñtéd chäråcterß", "Ðönt Rēmove Ácçeñtéd Chäråcterß"],
+            [
+                "Ðön't rēmove ácçeñtéd chäråcterß",
+                "Ðönt Rēmove Ácçeñtéd Chäråcterß",
+            ],
         ]
         for test in test_strings:
             with self.subTest(

--- a/test/unit/test_dataframe_handler.py
+++ b/test/unit/test_dataframe_handler.py
@@ -334,8 +334,8 @@ class TestDataframeHandler(TestCase):
             ["RanDom CAPITAL letters", "Random Capital Letters"],
             ["New Line\nIn The String", "New Line In The String"],
             [
-                "Ðön't rēmove ácçeñtéd chäråcterß",
-                "Ðönt Rēmove Ácçeñtéd Chäråcterß",
+                "Ðö nøt rēmove ácçeñtéd chäråcterß",
+                "Ðö Nøt Rēmove Ácçeñtéd Chäråcterß",
             ],
         ]
         for test in test_strings:

--- a/test/unit/test_dataframe_handler.py
+++ b/test/unit/test_dataframe_handler.py
@@ -333,6 +333,7 @@ class TestDataframeHandler(TestCase):
             [r"Non alphanumeric \ ! @", "Non Alphanumeric"],
             ["RanDom CAPITAL letters", "Random Capital Letters"],
             ["New Line\nIn The String", "New Line In The String"],
+            ["Ðön't rēmove ácçeñtéd chäråcterß", "Ðönt Rēmove Ácçeñtéd Chäråcterß"],
         ]
         for test in test_strings:
             with self.subTest(


### PR DESCRIPTION
**Reference Issue:**
Fixes #431 

**Description**
`dataframe_handler.py`'s `clean_strings` function uses the regex `[^a-zA-Z0-9 ]`, to remove non-alphanumeric characters in strings, but this function replaces all accented characters with spaces.

**Changes**

- Add test case for accented characters to unit tests
- Amend `[^a-zA-Z0-9 ]` to a different regex **(IN PROGRESS)**

