### PR TITLE
Fix incorrect merging of duplicate Inflow and Outflow columns

### DIFF
--- a/bank2ynab/dataframe_handler.py
+++ b/bank2ynab/dataframe_handler.py
@@ -258,27 +258,32 @@ def merge_duplicate_columns(
     for key in cols_to_merge:
         key_cols: list[int] = cols_to_merge[key]
         if len(key_cols) > 1:
-            # Build the merged values separately, then replace the column in one
-            # step so pandas does not try to coerce strings back into float dtype.
-            merged_col = df.iloc[:, key_cols[0]].fillna("").astype(str)
-            # merge every duplicate column into the 1st instance
-            # of the column name
-            for dupe_count, key_col in enumerate(key_cols[1:]):
-                # add string version of each column onto the first column
-                merged_col = (
-                    merged_col
-                    + " "
-                    + df.iloc[:, key_col].fillna("").astype(str)
+            if key in {"Inflow", "Outflow"}:
+                # merge numerically using fillna to preserve float dtype
+                for dupe_count, key_col in enumerate(key_cols[1:]):
+                    df.iloc[:, key_cols[0]] = df.iloc[:, key_cols[0]].fillna(
+                        df.iloc[:, key_col]
+                    )
+                    df.columns.values[key_col] = f"{key} {dupe_count}"
+            else:
+                # build the merged values separately, then replace the column in one
+                # step so pandas does not try to coerce strings back into float dtype.
+                merged_col = df.iloc[:, key_cols[0]].fillna("").astype(str)
+                # merge every duplicate column into the 1st instance
+                # of the column name
+                for dupe_count, key_col in enumerate(key_cols[1:]):
+                    merged_col = (
+                        merged_col
+                        + " "
+                        + df.iloc[:, key_col].fillna("").astype(str)
+                    )
+                    df.columns.values[key_col] = f"{key} {dupe_count}"
+                df.isetitem(
+                    key_cols[0],
+                    merged_col.str.replace(
+                        "\\s{2,}", " ", regex=True
+                    ).str.strip().to_numpy(),
                 )
-                # rename duplicate column
-                df.columns.values[key_col] = f"{key} {dupe_count}"
-            df.isetitem(
-                key_cols[0],
-                merged_col.str.replace(
-                    "\\s{2,}", " ", regex=True
-                ).str.strip().to_numpy(),
-            )
-            # remove excess spaces
 
     logging.debug(f"\nAfter duplicate merge\n{df.head()}")
     return df


### PR DESCRIPTION
**Reference Issue:**
Fixes #434 

**Description**
Fixes incorrect merging of Inflow and Outflow columns.
For example:

| Payee  | Inflow | Inflow | Expected merge result |
|--------|--------|--------|-----------------------|
| Github | -30.40 | NaN    | -30.40                |
| Bank   | NaN    | 55.50  | 55.50                 |

*Explain the changes that this pull request makes*
Excludes Inflow and Outflow columns from conversion to string before merging duplicates.