### PR TITLE
OCBC: strip quotes, update header rows

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -828,18 +828,20 @@ Input Columns = skip,skip,skip,skip,skip,Date,skip,skip,Payee,Memo,Inflow,skip
 Date Format = %Y-%m-%d
 
 [SG OCBC Bank]
+# Transaction date,Value date,Description,Withdrawals (SGD),Deposits (SGD), Payee
 Use Regex For Filename = True
 Source Filename Pattern = TransactionHistory_\d{4}\d{2}\d{2}\d{6}
 Header Rows = 6
 Footer Rows = 2
-Input Columns = Date,skip,Memo,Outflow,Inflow,skip
+Input Columns = Date,skip,Memo,Outflow,Inflow,Payee
 Date Format = %d/%m/%Y
 Plugin = OCBC_Bank_SG
 
 [SG OCBC Bank Credit Card]
+# Transaction date,Description,Withdrawals (SGD),Deposits (SGD)
 Use Regex For Filename = True
 Source Filename Pattern = TransactionHistory_\d{4}\d{2}\d{2}\d{6}
-Header Rows = 4
+Header Rows = 7
 Footer Rows = 2
 Input Columns = Date,Memo,Outflow,Inflow
 Date Format = %d/%m/%Y

--- a/bank2ynab/plugins/OCBC_Bank_SG.py
+++ b/bank2ynab/plugins/OCBC_Bank_SG.py
@@ -1,10 +1,11 @@
 # Plugin for handling OCBC Bank [SG] files
 
-from bank_handler import BankHandler
+from bank2ynab.bank_handler import BankHandler
 
 
 class OCBC_Bank_SG(BankHandler):
-    """Example subclass used for testing the plugin system."""
+    """Plugin for handling Oversea-Chinese Banking Corporation Singapore
+    (OCBC SG) bank files"""
 
     def __init__(self, config_dict: dict):
         """
@@ -31,6 +32,8 @@ class OCBC_Bank_SG(BankHandler):
         with open(file_path) as input_file:
             output_rows = []
             for rownum, row in enumerate(input_file):
+                # strip any single quotes, e.g. if payee is MCDONALD'S
+                row = row.replace("'","")
                 # append headers and footers without modification
                 if rownum < header_rows or rownum > (row_count - footer_rows):
                     output_rows.append(row)

--- a/bank2ynab/plugins/OCBC_Bank_SG.py
+++ b/bank2ynab/plugins/OCBC_Bank_SG.py
@@ -1,6 +1,6 @@
 # Plugin for handling OCBC Bank [SG] files
 
-from bank2ynab.bank_handler import BankHandler
+from bank_handler import BankHandler
 
 
 class OCBC_Bank_SG(BankHandler):
@@ -33,7 +33,7 @@ class OCBC_Bank_SG(BankHandler):
             output_rows = []
             for rownum, row in enumerate(input_file):
                 # strip any single quotes, e.g. if payee is MCDONALD'S
-                row = row.replace("'","")
+                row = row.replace("'", "")
                 # append headers and footers without modification
                 if rownum < header_rows or rownum > (row_count - footer_rows):
                     output_rows.append(row)


### PR DESCRIPTION
**Description**

Updates and fixes to handle the latest transaction history exports from OCBC bank in Singapore. 

**Explain the changes that this pull request makes**
- Strip single quotes (`'`) from lines as they are being processed by the OCBC plugin
- Update the OCBC import configurations to:
  - update the number of header rows for credit cards (there's 7 now)
  - also import payees for accounts\
- add a few comments / explanations