### PR TITLE
Change Source CSV Delimiter back to semi-colon and add an additional row to skip to 'CH ZKB Erweiterte Suche'

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -250,9 +250,9 @@ Delete Source File = False
 Use Regex For Filename = True
 Source Filename Pattern = ^Erweiterte Suche - Kontoauszug, Buchungen \d{14}
 Header Rows = 1
-Input Columns = Date,Payee,skip,skip,Outflow,Inflow
+Input Columns = Date,Payee,skip,skip,skip,Outflow,Inflow
 Date Format = %d.%m.%Y
-Source CSV Delimiter = ,
+Source CSV Delimiter = ;
 
 [CH ZKB Finanzassistent-Chronik]
 # Finanzassistent-Chronik.csv


### PR DESCRIPTION
**New Pull Request**

**Reference Issue:**
none


**Description**
In my previous pull request #442, I changed the Source CSV Delimiter for 'CH ZKB Erweiterte Suche' to a comma. As it seems this was a temporary change from the bank.

I had to change the Source CSV Delimiter for 'CH ZKB Erweiterte Suche' back to a semi-colon. Additionally, the bank introduced a new column to the file which can be skipped.
