### PR TITLE
fix file matching for DE Deutsche Kreditbank checking new

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -370,7 +370,7 @@ Date Format = %d.%m.%Y
 
 [DE Deutsche Kreditbank checking new]
 Use Regex For Filename = True
-Source Filename Pattern = [0-9]{2}-[0-9]{2}-[0-9]{4}_Umsatzliste_Girokonto_DE[0-9]{20}
+Source Filename Pattern = [0-9]{2}-[0-9]{2}-[0-9]{4}_Umsatzliste_[\S]*_DE[0-9]{20}
 Header Rows = 5
 Source CSV Delimiter = ;
 Input Columns = skip,Date,skip,skip,Payee,Memo,skip,Inflow,skip,skip,skip


### PR DESCRIPTION
**New Pull Request**
Relates #432 


**Description**
https://github.com/bank2ynab/bank2ynab/pull/444 added parsing for "DE Deutsche Kreditbank checking new" assuming that the filename would always include "Girokonto" in its name. But users can rename their bank accounts in the webinterface and the custom name is used to name the files. So everything between "Umsatzliste_" and "_DE" is a user controlled string, whitespace characters are replaced with "-" during the export.