### PR TITLE
Changed the regex for NL Knab to work with new files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ bank2ynab/workspace.code-workspace
 .DS_Store
 .AppleDouble
 .LSOverride
+.idea

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -698,7 +698,7 @@ Inflow or Outflow Indicator = 5,Bij,Af
 [NL KNAB]
 # Knab transactieoverzicht betaalrekening NL12KNAB0123456789 - 2020-08-10 - 2020-09-10.csv
 Use Regex for Filename = True
-Source Filename Pattern = Knab transactieoverzicht betaalrekening NL[0-9]{2}KNAB[0-9]* - [0-9]{4}-[0-9]{2}-[0-9]{2} - [0-9]{4}-[0-9]{2}-[0-9]{2}
+Source Filename Pattern = Knab Transactieoverzicht  betaalrekening  NL[0-9]{2}KNAB[0-9]+ - [0-9]{4}-[0-9]{2}-[0-9]{2} - [0-9]{4}-[0-9]{2}-[0-9]{2}
 Header Rows = 2
 Footer Rows = 0
 Source CSV Delimiter = ;


### PR DESCRIPTION
**New Pull Request**

**Reference Issue:**
#473

**Explain the changes that this pull request makes**
Changes the KNAB regex from 
```
Source Filename Pattern = Knab transactieoverzicht betaalrekening NL[0-9]{2}KNAB[0-9]* - [0-9]{4}-[0-9]{2}-[0-9]{2} - [0-9]{4}-[0-9]{2}-[0-9]{2}
```

To
```
Source Filename Pattern = Knab Transactieoverzicht  betaalrekening  NL[0-9]{2}KNAB[0-9]+ - [0-9]{4}-[0-9]{2}-[0-9]{2} - [0-9]{4}-[0-9]{2}-[0-9]{2}
```

To meet the newest file outputs

I was unable to run Python tests. This works in 'production'.