### PR TITLE
Fix panda crash if a str column is NaN

### DIFF
--- a/bank2ynab/dataframe_handler.py
+++ b/bank2ynab/dataframe_handler.py
@@ -377,7 +377,7 @@ def remove_invalid_rows(df: pd.DataFrame) -> pd.DataFrame:
     df.query("Inflow.notna() | Outflow.notna()", inplace=True)
     # filter rows with an invalid date
     df.query("Date.notna()", inplace=True)
-    df.fillna(0, inplace=True)
+    df.fillna(None, inplace=True)
     df.query("amount!=0", inplace=True)
     df.reset_index(inplace=True)
     return df


### PR DESCRIPTION
**New Pull Request**

**Description**


After recent Python and pandas upgrades, the tool failed for me with
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/raphael/personal/ynab/bank2ynab/bank2ynab/__main__.py", line 70, in <module>
    main()
    ~~~~^^
  File "/home/raphael/personal/ynab/bank2ynab/bank2ynab/__main__.py", line 53, in main
    bank_object.run()
    ~~~~~~~~~~~~~~~^^
  File "/home/raphael/personal/ynab/bank2ynab/bank2ynab/bank_handler.py", line 56, in run
    df_handler.run(
    ~~~~~~~~~~~~~~^
        file_path=src_file,
        ^^^^^^^^^^^^^^^^^^^
    ...<11 lines>...
        currency_fix=self.config_dict["currency_mult"],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/raphael/personal/ynab/bank2ynab/bank2ynab/dataframe_handler.py", line 84, in run
    self.df = parse_data(
              ~~~~~~~~~~^
        df=self.df,
        ^^^^^^^^^^^
    ...<7 lines>...
        currency_fix=currency_fix,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/raphael/personal/ynab/bank2ynab/bank2ynab/dataframe_handler.py", line 202, in parse_data
    df = remove_invalid_rows(df)
  File "/home/raphael/personal/ynab/bank2ynab/bank2ynab/dataframe_handler.py", line 383, in remove_invalid_rows
    df.fillna(0, inplace=True)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/raphael/.virtualenvs/bank2ynab/lib/python3.14/site-packages/pandas/core/generic.py", line 7159, in fillna
    new_data = self._mgr.fillna(value=value, limit=limit, inplace=inplace)
  File "/home/raphael/.virtualenvs/bank2ynab/lib/python3.14/site-packages/pandas/core/internals/managers.py", line 458, in fillna
    return self.apply(
           ~~~~~~~~~~^
        "fillna",
        ^^^^^^^^^
    ...<2 lines>...
        inplace=inplace,
        ^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/raphael/.virtualenvs/bank2ynab/lib/python3.14/site-packages/pandas/core/internals/managers.py", line 442, in apply
    applied = getattr(b, f)(**kwargs)
  File "/home/raphael/.virtualenvs/bank2ynab/lib/python3.14/site-packages/pandas/core/internals/blocks.py", line 1893, in fillna
    return super().fillna(
           ~~~~~~~~~~~~~~^
        value=value,
        ^^^^^^^^^^^^
        limit=limit,
        ^^^^^^^^^^^^
        inplace=inplace,
        ^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/raphael/.virtualenvs/bank2ynab/lib/python3.14/site-packages/pandas/core/internals/blocks.py", line 1342, in fillna
    nbs = self.putmask(mask.T, value)
  File "/home/raphael/.virtualenvs/bank2ynab/lib/python3.14/site-packages/pandas/core/internals/blocks.py", line 1774, in putmask
    values._putmask(mask, new)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/raphael/.virtualenvs/bank2ynab/lib/python3.14/site-packages/pandas/core/arrays/string_.py", line 887, in _putmask
    ExtensionArray._putmask(self, mask, value)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/raphael/.virtualenvs/bank2ynab/lib/python3.14/site-packages/pandas/core/arrays/base.py", line 2533, in _putmask
    self[mask] = val
    ~~~~^^^^^^
  File "/home/raphael/.virtualenvs/bank2ynab/lib/python3.14/site-packages/pandas/core/arrays/string_.py", line 863, in __setitem__
    value = self._maybe_convert_setitem_value(value)
  File "/home/raphael/.virtualenvs/bank2ynab/lib/python3.14/site-packages/pandas/core/arrays/string_.py", line 837, in _maybe_convert_setitem_value
    raise TypeError(
    ...<3 lines>...
    )
TypeError: Invalid value '0' for dtype 'str'. Value should be a string or missing value, got 'int' instead.
```
This seems to fix it