### PR TITLE
Add support for [CH ZKB Konto CSV-Export (Mit Details)] and [CH ZugerKB Kontoauszug] bank formats, Updated and unify existing Swiss bank configurations

### DIFF
--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -269,11 +269,12 @@ Date Format = %Y-%m-%d
 Source CSV Delimiter = ;
 
 [CH SwissCard]
+# Filename-Pattern: SC-Transactions_2026-02-16_06-56-22.csv
 Source Filename Pattern = SC-Transactions
 Header Rows = 1
 Footer Rows = 0
-# Transaktionsdatum,Beschreibung,Kartennummer,Währung,Betrag,Debit/Kredit,Status,Kategorie
-Input Columns = Date,Payee,skip,skip,Outflow,skip,skip,skip
+# Transaction date,Description,Merchant,Card number,Currency,Amount,Foreign Currency,Amount in foreign currency,Debit/Credit,Status,Merchant Category,Registered Category
+Input Columns = Date,Memo,Payee,skip,skip,Outflow,skip,skip,skip,skip,skip,skip
 Date Format = %d.%m.%Y
 Source CSV Delimiter = ,
 Delete Source File = False

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -259,7 +259,7 @@ Date Format = %Y-%m-%d
 Source CSV Delimiter = ;
 
 [CH Neon Yearly Account Statement]
-# 2025_account_statements.csv
+# Filename-Pattern: 2025_account_statements.csv
 Use Regex For Filename = True
 Source Filename Pattern = ^\d{4}_account_statements
 Header Rows = 1
@@ -272,23 +272,26 @@ Source CSV Delimiter = ;
 Source Filename Pattern = SC-Transactions
 Header Rows = 1
 Footer Rows = 0
-Input Columns = Date,Payee,skip,skip,Outflow,skip,skip,skip
 # Transaktionsdatum,Beschreibung,Kartennummer,Währung,Betrag,Debit/Kredit,Status,Kategorie
+Input Columns = Date,Payee,skip,skip,Outflow,skip,skip,skip
 Date Format = %d.%m.%Y
 Source CSV Delimiter = ,
 Delete Source File = False
 
-[CH ZKB Kontoauszug Valuta Date]
-# Kontoauszug 20250302210019.csv
+[CH ZKB Konto CSV-Export (Mit Details)]
+# HowTo: Konto > CSV-Export > Mit Details
+# Filters: Datumsart > Valuta
+# Filename-Pattern: Kontoauszug 20250302210019.csv
 Use Regex For Filename = True
 Source Filename Pattern = ^Kontoauszug\s\d{14}
 Header Rows = 1
+# "Datum";"Buchungstext";"Whg";"Betrag Detail";"ZKB-Referenz";"Referenznummer";"Belastung CHF";"Gutschrift CHF";"Valuta";"Saldo CHF";"Zahlungszweck";"Details"
 Input Columns = skip,Payee,skip,skip,skip,skip,Outflow,Inflow,Date,skip,Memo,skip
 Date Format = %d.%m.%Y
 Source CSV Delimiter = ;
 
 [CH ZKB Erweiterte Suche]
-# Erweiterte Suche - Kontoauszug, Buchungen 20190422162658.csv
+# Filename-Pattern: Erweiterte Suche - Kontoauszug, Buchungen 20190422162658.csv
 Use Regex For Filename = True
 Source Filename Pattern = ^Erweiterte Suche - Kontoauszug, Buchungen \d{14}
 Header Rows = 1

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -308,6 +308,16 @@ Input Columns = Date,Category,skip,Inflow,Memo,Payee,skip
 Date Format = %Y-%m-%d
 Source CSV Delimiter = ;
 
+[CH ZugerKB Kontoauszug]
+# Filename-Pattern: Auszug_31012026.csv 
+Use Regex For Filename = True
+Source Filename Pattern = ^Auszug_\d{8} 
+Header Rows = 12
+# Datum;Buchungstext;Betrag;Valuta
+Input Columns = skip,Payee,Inflow,Date
+Date Format = %d.%m.%y 
+Source CSV Delimiter = ;
+
 [CO Bancolombia]
 Source Filename Pattern = [0-9]{3}-[0-9]{6}-[0-9]{2}_[0-9]{3}
 Source Filename Extension = .txt

--- a/bank2ynab.conf
+++ b/bank2ynab.conf
@@ -278,6 +278,15 @@ Date Format = %d.%m.%Y
 Source CSV Delimiter = ,
 Delete Source File = False
 
+[CH ZKB Kontoauszug Valuta Date]
+# Kontoauszug 20250302210019.csv
+Use Regex For Filename = True
+Source Filename Pattern = ^Kontoauszug\s\d{14}
+Header Rows = 1
+Input Columns = skip,Payee,skip,skip,skip,skip,Outflow,Inflow,Date,skip,Memo,skip
+Date Format = %d.%m.%Y
+Source CSV Delimiter = ;
+
 [CH ZKB Erweiterte Suche]
 # Erweiterte Suche - Kontoauszug, Buchungen 20190422162658.csv
 Use Regex For Filename = True


### PR DESCRIPTION
 ### Description

**Added support for two new Swiss bank formats:**
- [CH ZKB Konto CSV-Export (Mit Details)] - Added configuration for ZKB account CSV exports with details
- [CH ZugerKB Kontoauszug] - Added support for Zuger Kantonalbank account statements

**Updated existing Swiss bank configurations:**
- Updated [CH SwissCard] configuration with correct input columns mapping (the external bank updated their CSV)
- Add comments & unify comments for additions [CH ZKB Konto CSV-Export (Mit Details)], [CH ZugerKB Kontoauszug], [CH SwissCard], [CH Neon Yearly Account Statement]
  - Added "Filename-Pattern" comments to several Swiss bank configurations to make it clearer what files they match

### Additional Information
- I checked the failed checks and consider them not necessary for my changes.