### PR TITLE
Add US Fidelity CMA history CSV format

### DIFF
--- a/bank2ynab/data/bank2ynab.conf
+++ b/bank2ynab/data/bank2ynab.conf
@@ -1133,6 +1133,18 @@ Use Regex for Filename = True
 Input Columns = skip,Date,skip,Memo,skip,skip,Inflow
 Date Format = %m/%d/%Y
 
+[US Fidelity CMA]
+# Example: History_for_Account_<ACCOUNT_ID>.csv
+# Fidelity Cash Management Account history export
+Use Regex For Filename = True
+Source Filename Pattern = History_for_Account.*
+Source Filename Extension = .csv
+Source CSV Delimiter = ,
+Header Rows = 3
+Footer Rows = 14
+Input Columns = Date,Payee,skip,Memo,skip,skip,skip,skip,skip,skip,Inflow,skip,skip
+Date Format = %m/%d/%Y
+
 [US Schwab Checking]
 # source: Issue #122
 Source Filename Pattern = Source Filename Pattern = XXXXXX[0-9]{6}_(Checking)_Transactions_[0-9]{8}-[0-9]{6}


### PR DESCRIPTION
Add support for Fidelity Cash Management Account (CMA) history CSV exports.

**New Pull Request**

**Reference Issue:**
N/A

**Description:**

Adds support for importing Fidelity Cash Management Account (CMA) transaction history CSV exports.

**Explain the changes that this pull request makes**

- Adds a new configuration section `[US Fidelity CMA]` to `bank2ynab.conf`
- Supports the 13-column Fidelity CMA history export format

**Notes / Limitations**

- Fidelity brokerage account exports use a different 17-column format and are not included in this change
- The filename pattern `History_for_Account.*` is used because Fidelity does not include account type in the filename
- Manually tested with successful CSV import into YNAB