### PR TITLE
Fix logging levels config and suppress PDF converter verbosity (#231, #491)

### DIFF
--- a/bank2ynab/__main__.py
+++ b/bank2ynab/__main__.py
@@ -5,7 +5,7 @@ from .config_handler import ConfigHandler
 from .ynab_api import YNAB_API
 
 # configure our logger
-logging.basicConfig(format="%(levelname): %(message)", level=logging.INFO)
+logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 def main() -> None:
@@ -15,6 +15,7 @@ def main() -> None:
         logging.error("No configuration file found, process aborted.")
         pass
     else:
+        logging.getLogger().setLevel(config_handler.get_log_level())
         # generate list of bank objects to process
         bank_obj_list: list[BankHandler] = []
         for bank_params in config_handler.config.sections():

--- a/bank2ynab/config_handler.py
+++ b/bank2ynab/config_handler.py
@@ -208,3 +208,16 @@ class ConfigHandler:
             list: Value matching parameter.
         """
         return self.config.get(section_name, param).split(splitter)
+
+    def get_log_level(self) -> int:
+        """Return the logging level integer from config, defaulting to WARNING.
+
+        Reads 'Log Level' from [DEFAULT]. Accepted values: DEBUG, INFO,
+        WARNING, ERROR, CRITICAL.
+        """
+        level_str = self.config.defaults().get("log level", "WARNING").upper()
+        level = getattr(logging, level_str, None)
+        if not isinstance(level, int):
+            logging.warning(f"Invalid log level '{level_str}', using WARNING.")
+            return logging.WARNING
+        return level

--- a/bank2ynab/data/user_configuration.conf.template
+++ b/bank2ynab/data/user_configuration.conf.template
@@ -7,3 +7,5 @@
 # Specify where you save your downloaded CSV files:
 Source Path =
 YNAB API Access Token =
+# Logging verbosity: DEBUG, INFO, WARNING, ERROR, CRITICAL (default: WARNING)
+Log Level = WARNING

--- a/bank2ynab/plugins/pdf_converter.py
+++ b/bank2ynab/plugins/pdf_converter.py
@@ -3,6 +3,9 @@ import logging
 import pandas as pd
 import pdfplumber
 
+logging.getLogger("pdfplumber").setLevel(logging.WARNING)
+logging.getLogger("pdfminer").setLevel(logging.WARNING)
+
 from .. import bank_handler
 from ..bank_handler import BankHandler
 from ..config_handler import BankConfig


### PR DESCRIPTION
## Summary

- Adds a `Log Level` key to `[DEFAULT]` in the conf file, read by a new `get_log_level()` method on `ConfigHandler`. Accepted values: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. Defaults to `WARNING`.
- Applies the configured level in `__main__.py` after config loads.
- Suppresses verbose `pdfplumber` and `pdfminer` logging at module level in `pdf_converter.py` regardless of user log level setting.
- Documents the new `Log Level` option in `user_configuration.conf.template`.

Closes #231, closes #491.