### PR TITLE
Make string cleaning of Payee/Memo fields optional, enabled by default (#465)

### DIFF
--- a/bank2ynab/bank_handler.py
+++ b/bank2ynab/bank_handler.py
@@ -64,6 +64,8 @@ class BankHandler:
                     date_dedupe=self.config.date_dedupe,
                     fill_memo=self.config.payee_to_memo,
                     currency_fix=self.config.currency_mult,
+                    clean_payee=self.config.clean_payee,
+                    clean_memo=self.config.clean_memo,
                 )
 
                 self.files_processed += 1

--- a/bank2ynab/config_handler.py
+++ b/bank2ynab/config_handler.py
@@ -37,6 +37,8 @@ class BankConfig:
     api_account: list[str]
     currency_mult: float
     save_output: bool
+    clean_payee: bool = True
+    clean_memo: bool = True
 
     def __post_init__(self) -> None:
         if self.input_delimiter == "\\t":
@@ -144,6 +146,8 @@ class ConfigHandler:
             api_account=self.config.get(section, "YNAB Account ID").split("|"),
             currency_mult=self.config.getfloat(section, "Currency Conversion Factor"),
             save_output=self.config.getboolean(section, "Save Output File"),
+            clean_payee=self.config.getboolean(section, "Clean Payee"),
+            clean_memo=self.config.getboolean(section, "Clean Memo"),
         )
 
     def get_config_line_str(self, section_name: str, param: str) -> str:

--- a/bank2ynab/data/bank2ynab.conf
+++ b/bank2ynab/data/bank2ynab.conf
@@ -24,6 +24,9 @@ Output Columns = Date,Payee,Category,Memo,Outflow,Inflow
 Output Filename Prefix = fixed_
 Output Filename Extension = .csv
 Use Payee for Memo = True
+# Set to False to preserve original Payee/Memo text without string cleaning
+Clean Payee = True
+Clean Memo = True
 API Transaction Fields = account_id,date,payee_name,amount,memo,category,cleared,import_id
 # Post-processing
 Delete Source File = True

--- a/bank2ynab/dataframe_handler.py
+++ b/bank2ynab/dataframe_handler.py
@@ -35,6 +35,8 @@ class DataframeHandler:
         date_dedupe: bool,
         fill_memo: bool,
         currency_fix: float,
+        clean_payee: bool = True,
+        clean_memo: bool = True,
     ) -> None:
         """Complete handling of Dataframe creation & output.
 
@@ -52,6 +54,8 @@ class DataframeHandler:
             date_dedupe: Whether to fill in date with previous if blank.
             fill_memo: Whether to fill blank memo with payee data.
             currency_fix: Value to divide all currency amounts by.
+            clean_payee: Whether to apply string cleaning to Payee field.
+            clean_memo: Whether to apply string cleaning to Memo field.
         """
         # read data from input file to dataframe
         self.df = read_csv(
@@ -72,6 +76,8 @@ class DataframeHandler:
             date_dedupe=date_dedupe,
             fill_memo=fill_memo,
             currency_fix=currency_fix,
+            clean_payee=clean_payee,
+            clean_memo=clean_memo,
         )
         # check if dataframe is empty
         self.empty = self.df.empty
@@ -127,6 +133,8 @@ def parse_data(
     date_dedupe: bool,
     fill_memo: bool,
     currency_fix: float,
+    clean_payee: bool = True,
+    clean_memo: bool = True,
 ) -> pd.DataFrame:
     """Convert each column of the dataframe to match ideal output data.
 
@@ -140,6 +148,8 @@ def parse_data(
         date_dedupe: Whether to fill in date with previous if blank.
         fill_memo: Whether to fill blank memo with payee data.
         currency_fix: Value to divide all currency amounts by.
+        clean_payee: Whether to apply string cleaning to Payee field.
+        clean_memo: Whether to apply string cleaning to Memo field.
 
     Returns:
         pd.DataFrame: Modified dataframe matching provided configuration values.
@@ -167,8 +177,10 @@ def parse_data(
     # auto fill payee from memo
     df = auto_payee(df)
     # fix strings
-    df["Payee"] = clean_strings(df["Payee"])
-    df["Memo"] = clean_strings(df["Memo"])
+    if clean_payee:
+        df["Payee"] = clean_strings(df["Payee"])
+    if clean_memo:
+        df["Memo"] = clean_strings(df["Memo"])
     # remove invalid rows
     df = remove_invalid_rows(df)
     # fill API-specific columns


### PR DESCRIPTION
## Summary

- Adds `Clean Payee` and `Clean Memo` boolean keys to `[DEFAULT]` in `bank2ynab.conf`, both defaulting to `True` for backwards compatibility.
- `ConfigHandler.fix_conf_params()` reads both keys.
- `DataframeHandler.run()` and `parse_data()` accept `clean_payee` and `clean_memo` parameters; each `clean_strings()` call is guarded by the respective flag.
- `BankHandler` passes both values from config when invoking the dataframe handler.

Closes #465.
