### PR TITLE
Add payee rename/transformation map config support (#404)

### DIFF
--- a/bank2ynab/bank_handler.py
+++ b/bank2ynab/bank_handler.py
@@ -64,6 +64,7 @@ class BankHandler:
                     date_dedupe=self.config.date_dedupe,
                     fill_memo=self.config.payee_to_memo,
                     currency_fix=self.config.currency_mult,
+                    payee_mappings=self.config.payee_mappings,
                 )
 
                 self.files_processed += 1

--- a/bank2ynab/config_handler.py
+++ b/bank2ynab/config_handler.py
@@ -3,7 +3,7 @@ import logging
 import os
 import shutil
 import typing
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
 
@@ -37,6 +37,7 @@ class BankConfig:
     api_account: list[str]
     currency_mult: float
     save_output: bool
+    payee_mappings: dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.input_delimiter == "\\t":
@@ -144,6 +145,9 @@ class ConfigHandler:
             api_account=self.config.get(section, "YNAB Account ID").split("|"),
             currency_mult=self.config.getfloat(section, "Currency Conversion Factor"),
             save_output=self.config.getboolean(section, "Save Output File"),
+            payee_mappings=dict(self.config.items(f"{section} payee_mappings"))
+            if self.config.has_section(f"{section} payee_mappings")
+            else {},
         )
 
     def get_config_line_str(self, section_name: str, param: str) -> str:

--- a/bank2ynab/config_handler.py
+++ b/bank2ynab/config_handler.py
@@ -145,7 +145,11 @@ class ConfigHandler:
             api_account=self.config.get(section, "YNAB Account ID").split("|"),
             currency_mult=self.config.getfloat(section, "Currency Conversion Factor"),
             save_output=self.config.getboolean(section, "Save Output File"),
-            payee_mappings=dict(self.config.items(f"{section} payee_mappings"))
+            payee_mappings={
+                k: v
+                for k, v in self.config.items(f"{section} payee_mappings")
+                if k not in self.config.defaults()
+            }
             if self.config.has_section(f"{section} payee_mappings")
             else {},
         )

--- a/bank2ynab/data/bank2ynab.conf
+++ b/bank2ynab/data/bank2ynab.conf
@@ -42,6 +42,15 @@ YNAB Account ID =
 # Just make a new [section heading] and copy only the lines from above that need a non-default value.
 # Please keep this sorted alphabetically by [country + bank name] for easier maintenance.
 #####################################################################################################
+# PAYEE RENAME MAPPINGS:
+# To rename payees for a bank, add a companion section named "[BankName payee_mappings]".
+# Each line is:  raw string to match = Friendly Name
+# Matching is case-insensitive substring; first match wins.
+# Example:
+#   [My Bank payee_mappings]
+#   PAYPAL (EUROPE) S.A.R.L ET CIE,S.C.A. = PayPal
+#   AMAZON EU = Amazon
+#####################################################################################################
 # DATE FORMATS:
 # %y   2-digit year
 # %Y   4-digit year

--- a/bank2ynab/dataframe_handler.py
+++ b/bank2ynab/dataframe_handler.py
@@ -4,8 +4,6 @@ import pandas as pd
 
 
 class DataframeHandler:
-    # TODO - integrate payee mapping in this class
-
     """Use config to produce a cleaned dataframe matching a given specification."""
 
     def __init__(self) -> None:
@@ -35,6 +33,7 @@ class DataframeHandler:
         date_dedupe: bool,
         fill_memo: bool,
         currency_fix: float,
+        payee_mappings: dict[str, str] | None = None,
     ) -> None:
         """Complete handling of Dataframe creation & output.
 
@@ -52,6 +51,7 @@ class DataframeHandler:
             date_dedupe: Whether to fill in date with previous if blank.
             fill_memo: Whether to fill blank memo with payee data.
             currency_fix: Value to divide all currency amounts by.
+            payee_mappings: Optional dict of raw payee substring → friendly name.
         """
         # read data from input file to dataframe
         self.df = read_csv(
@@ -72,6 +72,7 @@ class DataframeHandler:
             date_dedupe=date_dedupe,
             fill_memo=fill_memo,
             currency_fix=currency_fix,
+            payee_mappings=payee_mappings or {},
         )
         # check if dataframe is empty
         self.empty = self.df.empty
@@ -127,6 +128,7 @@ def parse_data(
     date_dedupe: bool,
     fill_memo: bool,
     currency_fix: float,
+    payee_mappings: dict[str, str] | None = None,
 ) -> pd.DataFrame:
     """Convert each column of the dataframe to match ideal output data.
 
@@ -140,6 +142,7 @@ def parse_data(
         date_dedupe: Whether to fill in date with previous if blank.
         fill_memo: Whether to fill blank memo with payee data.
         currency_fix: Value to divide all currency amounts by.
+        payee_mappings: Optional dict of raw payee substring → friendly name.
 
     Returns:
         pd.DataFrame: Modified dataframe matching provided configuration values.
@@ -166,6 +169,8 @@ def parse_data(
     df = auto_memo(df, fill_memo)
     # auto fill payee from memo
     df = auto_payee(df)
+    # apply payee rename mappings
+    df = apply_payee_mappings(df, payee_mappings or {})
     # fix strings
     df["Payee"] = clean_strings(df["Payee"])
     df["Memo"] = clean_strings(df["Memo"])
@@ -180,6 +185,35 @@ def parse_data(
     # view final dataframe
     logging.debug(f"\nFinal DF\n{df.head(10)}")
 
+    return df
+
+
+def apply_payee_mappings(
+    df: pd.DataFrame, payee_mappings: dict[str, str]
+) -> pd.DataFrame:
+    """Replace raw payee strings with friendly names from a mapping dict.
+
+    Matching is case-insensitive substring; first match wins.
+
+    Args:
+        df: Dataframe to modify.
+        payee_mappings: Dict of raw substring → friendly name.
+
+    Returns:
+        pd.DataFrame: Modified dataframe.
+    """
+    if not payee_mappings:
+        return df
+
+    def map_payee(payee: str) -> str:
+        if pd.isna(payee):
+            return payee
+        for raw, friendly in payee_mappings.items():
+            if raw.lower() in str(payee).lower():
+                return friendly
+        return payee
+
+    df["Payee"] = df["Payee"].apply(map_payee)
     return df
 
 

--- a/bank2ynab/dataframe_handler.py
+++ b/bank2ynab/dataframe_handler.py
@@ -51,7 +51,7 @@ class DataframeHandler:
             date_dedupe: Whether to fill in date with previous if blank.
             fill_memo: Whether to fill blank memo with payee data.
             currency_fix: Value to divide all currency amounts by.
-            payee_mappings: Optional dict of raw payee substring → friendly name.
+            payee_mappings: Dict of raw payee substring → friendly name; omit or pass None for no mapping.
         """
         # read data from input file to dataframe
         self.df = read_csv(
@@ -128,7 +128,7 @@ def parse_data(
     date_dedupe: bool,
     fill_memo: bool,
     currency_fix: float,
-    payee_mappings: dict[str, str] | None = None,
+    payee_mappings: dict[str, str],
 ) -> pd.DataFrame:
     """Convert each column of the dataframe to match ideal output data.
 
@@ -142,7 +142,7 @@ def parse_data(
         date_dedupe: Whether to fill in date with previous if blank.
         fill_memo: Whether to fill blank memo with payee data.
         currency_fix: Value to divide all currency amounts by.
-        payee_mappings: Optional dict of raw payee substring → friendly name.
+        payee_mappings: Dict of raw payee substring → friendly name.
 
     Returns:
         pd.DataFrame: Modified dataframe matching provided configuration values.
@@ -170,7 +170,7 @@ def parse_data(
     # auto fill payee from memo
     df = auto_payee(df)
     # apply payee rename mappings
-    df = apply_payee_mappings(df, payee_mappings or {})
+    df = apply_payee_mappings(df, payee_mappings)
     # fix strings
     df["Payee"] = clean_strings(df["Payee"])
     df["Memo"] = clean_strings(df["Memo"])

--- a/test/unit/test_config_handler.py
+++ b/test/unit/test_config_handler.py
@@ -29,6 +29,30 @@ class TestConfigHandlerPaths(unittest.TestCase):
             self.assertTrue(bank_conf.exists())
             self.assertTrue(user_conf.exists())
 
+    def test_payee_mappings_excludes_default_section_keys(self) -> None:
+        """DEFAULT section keys must not bleed into payee_mappings."""
+        with tempfile.TemporaryDirectory() as temp_config:
+            os.environ["BANK2YNAB_CONFIG_DIR"] = temp_config
+
+            # Let ConfigHandler seed bank2ynab.conf (supplies all DEFAULT values),
+            # then append a test bank + its payee_mappings to the user conf.
+            handler = ConfigHandler()
+            user_conf = Path(handler.user_conf_path)
+            user_conf.write_text(
+                "[Test Bank]\n"
+                "\n"
+                "[Test Bank payee_mappings]\n"
+                "PAYPAL = PayPal\n"
+                "AMAZON = Amazon\n",
+                encoding="utf-8",
+            )
+            handler = ConfigHandler()
+            config = handler.fix_conf_params("Test Bank")
+
+        self.assertEqual(config.payee_mappings, {"paypal": "PayPal", "amazon": "Amazon"})
+        for default_key in handler.config.defaults():
+            self.assertNotIn(default_key, config.payee_mappings)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit/test_dataframe_handler.py
+++ b/test/unit/test_dataframe_handler.py
@@ -7,6 +7,7 @@ from pandas._libs.missing import NA
 
 from bank2ynab.dataframe_handler import (
     add_missing_columns,
+    apply_payee_mappings,
     auto_memo,
     auto_payee,
     cd_flag_process,
@@ -539,3 +540,35 @@ class TestDataframeHandler(TestCase):
         expected_output = pd.DataFrame({"Col1": [45, 55], "Col2": [36, 98]})
         test_output = combine_dfs(dfs)
         pandas.testing.assert_frame_equal(expected_output, test_output)
+
+    def test_apply_payee_mappings_match(self):
+        """Exact match replaces payee."""
+        df = pd.DataFrame({"Payee": ["PAYPAL (EUROPE) S.A.R.L ET CIE,S.C.A."]})
+        result = apply_payee_mappings(df, {"PAYPAL (EUROPE)": "PayPal"})
+        self.assertEqual(result["Payee"].iloc[0], "PayPal")
+
+    def test_apply_payee_mappings_no_match(self):
+        """Non-matching payee is left unchanged."""
+        df = pd.DataFrame({"Payee": ["AMAZON EU"]})
+        result = apply_payee_mappings(df, {"PAYPAL": "PayPal"})
+        self.assertEqual(result["Payee"].iloc[0], "AMAZON EU")
+
+    def test_apply_payee_mappings_case_insensitive(self):
+        """Matching is case-insensitive."""
+        df = pd.DataFrame({"Payee": ["paypal europe"]})
+        result = apply_payee_mappings(df, {"PAYPAL": "PayPal"})
+        self.assertEqual(result["Payee"].iloc[0], "PayPal")
+
+    def test_apply_payee_mappings_first_match_wins(self):
+        """First matching mapping wins when multiple keys match."""
+        df = pd.DataFrame({"Payee": ["PAYPAL AMAZON"]})
+        result = apply_payee_mappings(
+            df, {"PAYPAL": "PayPal", "AMAZON": "Amazon"}
+        )
+        self.assertEqual(result["Payee"].iloc[0], "PayPal")
+
+    def test_apply_payee_mappings_empty(self):
+        """Empty mappings dict leaves payee unchanged."""
+        df = pd.DataFrame({"Payee": ["SOME PAYEE"]})
+        result = apply_payee_mappings(df, {})
+        self.assertEqual(result["Payee"].iloc[0], "SOME PAYEE")


### PR DESCRIPTION
## Summary

Adds a payee rename/transformation map so users can rewrite raw bank payee strings to friendly names via config, without touching code.

- New optional `[BankName payee_mappings]` section in each bank's `.conf` file. Each entry is `raw substring = Friendly Name`.
- Matching is case-insensitive substring; first match wins.
- `ConfigHandler` reads the section into a `payee_mappings` dict alongside other bank config.
- New `apply_payee_mappings()` function in `dataframe_handler.py`, applied after payee extraction but before `clean_strings()`.
- `BankHandler` passes the mappings dict through to the dataframe handler.
- `bank2ynab.conf` documents the new section with a commented example.
- 5 unit tests: match replaces, no-match unchanged, case-insensitive, first-match-wins, empty dict no-op.

Example usage in a bank conf file:
```
[My Bank payee_mappings]
PAYPAL (EUROPE) S.A.R.L ET CIE,S.C.A. = PayPal
AMAZON EU = Amazon
```

Closes #404.
