### PR TITLE
Fix mixed date/datetime format columns (#482)

### DIFF
--- a/bank2ynab/dataframe_handler.py
+++ b/bank2ynab/dataframe_handler.py
@@ -168,9 +168,10 @@ def parse_data(
     merge_duplicate_columns(df, input_columns)
     # add missing columns
     add_missing_columns(df, input_columns, output_columns + api_columns)
-    # fix date format
+    # fix date format — keep as datetime while filling, then format to ISO string
     df["Date"] = fix_date(df["Date"], date_format)
     df["Date"] = fill_empty_dates(df["Date"], date_dedupe)
+    df["Date"] = df["Date"].dt.strftime("%Y-%m-%d")
     # fix inflow/outflow string formatting
     df["Inflow"] = clean_monetary_values(df["Inflow"])
     df["Outflow"] = clean_monetary_values(df["Outflow"])
@@ -465,30 +466,51 @@ def clean_strings(string_series: pd.Series) -> pd.Series:
 
 
 def fix_date(date_series: pd.Series, date_format: str) -> pd.Series:
-    """Process dates from input format to ISO format.
+    """Parse dates to datetime, accepting values with or without a time component.
 
-    Any non-parseable dates are returned as a NaT null value.
+    Tries the configured format first. Rows that fail (NaT) are retried with
+    the same format plus a " %H:%M:%S" suffix, so a mixed column — some cells
+    date-only, others date+time — is handled transparently.
+
+    Any values that still cannot be parsed are returned as NaT.
 
     Args:
         date_series: Series of dates to process.
         date_format: Date format codes per the 1989 C standard.
 
     Returns:
-        pd.Series: Series with dates in ISO format.
+        pd.Series: Series of datetime64 values (NaT for unparseable entries).
     """
-    formatted_date_series = pd.to_datetime(
-        date_series,
-        format=date_format,
-        errors="coerce",
-    ).dt.strftime("%Y-%m-%d")
+    result = pd.to_datetime(date_series, format=date_format, errors="coerce")
 
-    logging.debug(f"\nFixed dates:\n{date_series.head()}")
+    # Only retry with a time suffix when the configured format is date-only;
+    # formats that already include time codes would produce duplicate regex groups.
+    _time_codes = {"%H", "%I", "%M", "%S", "%p", "%f"}
+    format_has_time = any(code in date_format for code in _time_codes)
 
-    return formatted_date_series
+    if not format_has_time:
+        failed = result.isna() & date_series.notna() & (
+            date_series.astype(str).str.strip() != ""
+        )
+        if failed.any():
+            retry = pd.to_datetime(
+                date_series[failed],
+                format=date_format + " %H:%M:%S",
+                errors="coerce",
+            )
+            result = result.copy()
+            result[failed] = retry
+
+    logging.debug(f"\nFixed dates:\n{result.head()}")
+
+    return result
 
 
 def fill_empty_dates(date_series: pd.Series, fill_dates: bool) -> pd.Series:
     """Fill in empty dates with values from previous cells.
+
+    Expects a datetime64 series; NaT values are propagated forward when
+    fill_dates is True.
 
     Args:
         date_series: Data series to modify.
@@ -498,7 +520,6 @@ def fill_empty_dates(date_series: pd.Series, fill_dates: bool) -> pd.Series:
         pd.Series: Modified data series.
     """
     if fill_dates:
-        date_series = date_series.replace(r"^\s*$", pd.NA, regex=True)
         date_series = date_series.ffill()
 
     return date_series

--- a/test/unit/test_dataframe_handler.py
+++ b/test/unit/test_dataframe_handler.py
@@ -399,6 +399,7 @@ class TestDataframeHandler(TestCase):
                 pandas.testing.assert_series_equal(desired_output, test_output)
 
     def test_fix_date(self):
+        """fix_date returns datetime64 values; invalid dates become NaT."""
         test_params = [
             {
                 "date_format": "%Y-%m-%d",
@@ -407,6 +408,12 @@ class TestDataframeHandler(TestCase):
                     "b": "2021-09-21",
                     "c": "2021-02-29",
                     "d": "2001-10-01",
+                },
+                "expected": {
+                    "a": pd.Timestamp("2021-10-01"),
+                    "b": pd.Timestamp("2021-09-21"),
+                    "c": pd.NaT,
+                    "d": pd.Timestamp("2001-10-01"),
                 },
             },
             {
@@ -417,6 +424,12 @@ class TestDataframeHandler(TestCase):
                     "c": "20210229",
                     "d": "20011001",
                 },
+                "expected": {
+                    "a": pd.Timestamp("2021-10-01"),
+                    "b": pd.Timestamp("2021-09-21"),
+                    "c": pd.NaT,
+                    "d": pd.Timestamp("2001-10-01"),
+                },
             },
             {
                 "date_format": "%d.%m.%Y",
@@ -425,6 +438,12 @@ class TestDataframeHandler(TestCase):
                     "b": "21.09.2021",
                     "c": "29.02.2021",
                     "d": "01.10.2001",
+                },
+                "expected": {
+                    "a": pd.Timestamp("2021-10-01"),
+                    "b": pd.Timestamp("2021-09-21"),
+                    "c": pd.NaT,
+                    "d": pd.Timestamp("2001-10-01"),
                 },
             },
             {
@@ -435,40 +454,61 @@ class TestDataframeHandler(TestCase):
                     "c": "2021-02-29 01:59:44",
                     "d": "2001-10-01 01:10:35",
                 },
+                "expected": {
+                    "a": pd.Timestamp("2021-10-01 01:02:03"),
+                    "b": pd.Timestamp("2021-09-21 01:32:02"),
+                    "c": pd.NaT,
+                    "d": pd.Timestamp("2001-10-01 01:10:35"),
+                },
             },
         ]
-        desired_output = pd.Series(
-            data={
-                "a": "2021-10-01",
-                "b": "2021-09-21",
-                "c": NA,
-                "d": "2001-10-01",
-            }
-        )
         for test in test_params:
             with self.subTest(test=test):
-                test_series = fix_date(
-                    pd.Series(data=test["data"]), test["date_format"]
+                result = fix_date(pd.Series(data=test["data"]), test["date_format"])
+                pandas.testing.assert_series_equal(
+                    pd.Series(data=test["expected"]), result
                 )
-                pandas.testing.assert_series_equal(desired_output, test_series)
 
-    def test_fill_empty_dates(self):
-        """Test filling in of empty date values."""
+    def test_fix_date_mixed_format(self):
+        """fix_date parses a column where some rows have a time component."""
         test_series = pd.Series(
             data={
-                "a": "2021-10-01",
-                "b": "2021-09-21",
-                "c": "",
-                "d": "2001-10-01",
+                "a": "01.10.2021",
+                "b": "21.09.2021 14:30:00",
+                "c": "29.02.2021 08:00:00",
+                "d": "01.10.2001 00:00:00",
+            }
+        )
+        # fix_date preserves the parsed time; stripping to date-only happens
+        # in parse_data via dt.strftime after this function returns.
+        desired_output = pd.Series(
+            data={
+                "a": pd.Timestamp("2021-10-01"),
+                "b": pd.Timestamp("2021-09-21 14:30:00"),
+                "c": pd.NaT,
+                "d": pd.Timestamp("2001-10-01 00:00:00"),
+            }
+        )
+        result = fix_date(test_series, "%d.%m.%Y")
+        pandas.testing.assert_series_equal(desired_output, result)
+
+    def test_fill_empty_dates(self):
+        """Test filling in of empty date values with a datetime64 series."""
+        test_series = pd.Series(
+            data={
+                "a": pd.Timestamp("2021-10-01"),
+                "b": pd.Timestamp("2021-09-21"),
+                "c": pd.NaT,
+                "d": pd.Timestamp("2001-10-01"),
             }
         )
 
         target_filled_series = pd.Series(
             data={
-                "a": "2021-10-01",
-                "b": "2021-09-21",
-                "c": "2021-09-21",
-                "d": "2001-10-01",
+                "a": pd.Timestamp("2021-10-01"),
+                "b": pd.Timestamp("2021-09-21"),
+                "c": pd.Timestamp("2021-09-21"),
+                "d": pd.Timestamp("2001-10-01"),
             }
         )
 


### PR DESCRIPTION
## Summary

- Banks such as SE Morrow Bank now export CSVs where some rows have a date-only value (e.g. `01.10.2021`) and others include a time component (e.g. `01.10.2021 14:30:00`). The single configured `Date Format` could only match one variant; the other rows were silently dropped.
- `fix_date` now parses the date column to `datetime64` internally. For date-only formats, any rows that fail the primary parse are retried with a time suffix. A guard prevents the retry when the format already contains time codes (which would produce duplicate regex groups).
- `fill_empty_dates` is simplified: NaT is a proper null on a datetime series, so the previous string-based empty-string replacement is no longer needed.
- `parse_data` formats the datetime column to an ISO string (`%Y-%m-%d`) immediately after the date operations. All downstream consumers — `fill_api_columns`, CSV output — are unchanged.

## Test plan

- [ ] `test_fix_date` updated: each format variant now has its own expected output (datetime64 not strings); time-preserving formats verified correctly
- [ ] `test_fix_date_mixed_format` added: covers the exact Morrow Bank scenario (mixed date/datetime column with an invalid date row)
- [ ] `test_fill_empty_dates` updated: uses datetime series as input; NaT forward-fill verified
- [ ] Full unit suite passes (31 passed, 13 skipped)

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)
