### PR TITLE
ci: fix and improve GitHub Actions workflows (#504-#509)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -15,8 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
-      - name: Run ruff (critical checks)
-        run: uvx ruff check . --select F,E9,I --output-format=github
+      - name: Check formatting
+        run: uvx ruff format --check .
+      - name: Run ruff
+        run: uvx ruff check . --output-format=github
 
   autofix:
     if: github.event_name == 'push'

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -7,14 +7,31 @@ on:
       - develop
   pull_request:
 
-permissions:
-  contents: read
-
 jobs:
   lint:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
       - name: Run ruff (critical checks)
         run: uvx ruff check . --select F,E9,I --output-format=github
+
+  autofix:
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: Auto-fix with ruff
+        run: |
+          uvx ruff check --fix .
+          uvx ruff format .
+      - name: Commit fixes if any
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git diff --quiet || (git add -A && git commit -m "style: auto-fix ruff violations" && git push)

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on:
   push:
+    branches:
+      - main
+      - develop
   pull_request:
 
 permissions:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -16,6 +16,4 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/labeler@v4
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+    - uses: actions/labeler@v5

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,6 +2,9 @@ name: Python testing
 
 on:
   push:
+    branches:
+      - main
+      - develop
   pull_request:
     paths-ignore:
       - "docs/**"
@@ -11,7 +14,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: testing-${{ github.workflow }}-${{ github.ref }}
+  group: testing-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -1,7 +1,10 @@
 name: Update README
 
 on:
-  pull_request:
+  push:
+    branches:
+      - main
+      - develop
     paths:
       - "bank2ynab/**"
       - "bank2ynab/data/**"
@@ -16,23 +19,20 @@ jobs:
     name: Update bank list
     runs-on: ubuntu-latest
 
-    steps:    
+    steps:
         - name: Check out Git repository
           uses: actions/checkout@v4
-          with:
-            ref: ${{ github.event.pull_request.head.ref }}
-        
+
         - name: Set up Python
           uses: actions/setup-python@v5
           with:
             python-version: "3.12"
-               
+
         - name: Update README.md
           id: update_readme
           uses: bank2ynab/bank2ynab-update-readme@master
-          
+
         - name: Commit and push changes
-          if: github.event.pull_request.head.repo.full_name == github.repository
           run: |
             git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git config --local user.name "github-actions[bot]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,6 @@ default-groups = ["dev"]
 [tool.ruff]
 line-length = 79
 target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "UP"]


### PR DESCRIPTION
﻿## Summary

Six targeted improvements to the CI workflows, one commit per issue.

| Commit | Issue | Change |
|--------|-------|--------|
| 1 | #504 | Restrict lint push trigger to main/develop -- stops double-run on PR commits |
| 2 | #505 | Restrict testing push trigger to main/develop; fix concurrency key so PR and push events share a group |
| 3 | #506 | Add post-merge autofix job to lint workflow -- runs ruff check --fix and ruff format, commits back to the protected branch |
| 4 | #507 | Expand ruff rule coverage (E, F, I, W, UP) via pyproject.toml; add ruff format --check step to PR checks |
| 5 | #508 | Add .github/dependabot.yml for weekly Actions updates; move update_readme to post-merge trigger to avoid fork permission failures |
| 6 | #509 | Upgrade actions/labeler from v4 to v5; remove now-unnecessary repo-token input |

## Notes

- Auto-fix (#506) and update_readme (#508) now both run on push to main/develop rather than on pull_request. This avoids the write-permission problem for fork PRs entirely.
- Dependabot (#508) will open a follow-up PR to pin bank2ynab-update-readme@master to a specific SHA once it runs.
- The expanded ruff rules (#507) may surface existing violations -- those will be cleaned up automatically by the new autofix job on merge to develop.
