### PR TITLE
fix: prevent autofix job crash; restrict lint to PRs only

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   lint:
+    if: github.event_name == 'pull_request'
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -30,7 +31,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - name: Auto-fix with ruff
         run: |
-          uvx ruff check --fix .
+          uvx ruff check --fix . || true
           uvx ruff format .
       - name: Commit fixes if any
         run: |


### PR DESCRIPTION
Two bugs introduced with the new codestyle.yml structure.

**Bug 1 — autofix crashes before committing**

\uff check --fix\ exits with code 1 when violations remain that it cannot auto-fix (e.g. \E501\ in docstrings, \E402\ after an intentional logging suppression call). The step dies immediately and the commit step never runs. Fix: \|| true\ so the step always exits cleanly after fixing whatever it can.

**Bug 2 — lint and autofix run in parallel on the same commit**

Both jobs triggered simultaneously on push, so lint was checking the un-fixed SHA regardless of what autofix did. Lint on a protected branch post-merge is also redundant — autofix is responsible for cleanup there. Fix: \if: github.event_name == 'pull_request'\ on the lint job so it only runs as a PR gate.