### PR TITLE
Publish workflow: TestPyPI pre-flight and PyPI release on tag

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -15,9 +15,9 @@ changelog:
         - bug
     - title: Internal & CI
       labels:
-        - CI
+        - automation
         - optimisation
         - meta
         - packaging
         - distribution
-        - documentation
+        - docs

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking
+    - title: New Features
+      labels:
+        - enhancement
+        - bank format
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Internal & CI
+      labels:
+        - CI
+        - optimisation
+        - meta
+        - packaging
+        - distribution
+        - documentation

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,11 +15,11 @@ jobs:
     name: Test gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - run: uv run python -m pytest
@@ -29,10 +29,13 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
       - run: uv build
       - run: uvx twine check dist/*
       - uses: actions/upload-artifact@v4
@@ -40,11 +43,11 @@ jobs:
           name: dist
           path: dist/
 
-  publish:
-    name: Publish to PyPI
+  publish-testpypi:
+    name: Publish to TestPyPI
     needs: build
     runs-on: ubuntu-latest
-    environment: pypi
+    environment: testpypi
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -55,15 +58,27 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+        continue-on-error: true
 
       - name: Verify TestPyPI install
         run: |
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
-          pip install \
+          uv pip install \
             --index-url https://test.pypi.org/simple/ \
             --extra-index-url https://pypi.org/simple/ \
             "bank2ynab==${VERSION}"
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,9 @@
-name: Publish (inactive)
+name: Publish to PyPI
 
 on:
-  # Manual trigger only while inactive.
+  push:
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
 
 permissions:
@@ -9,27 +11,59 @@ permissions:
   id-token: write
 
 jobs:
-  publish:
-    # Inactive by design. To activate:
-    # 1) remove this line
-    # 2) add a tag trigger under `on` (e.g. push.tags: ["v*"])
-    if: ${{ false }}
+  test:
+    name: Test gate
     runs-on: ubuntu-latest
-
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.12"
+          enable-cache: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: uv run python -m pytest
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+  build:
+    name: Build distribution
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv build
+      - run: uvx twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
-      - name: Build distributions
-        run: uv build
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Verify TestPyPI install
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          pip install \
+            --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple/ \
+            "bank2ynab==${VERSION}"
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Rewrites `publish.yml` from a disabled skeleton into a production-ready tag-triggered workflow
- Three-job sequence: test gate → build (uv build + twine check) → publish (TestPyPI upload, install verification, PyPI upload)
- Uses OIDC Trusted Publishers — no API token required
- Adds `.github/release.yml` to define auto-generated release note categories

## Test plan
- [ ] Confirm workflow YAML is syntactically valid
- [ ] Trigger via `workflow_dispatch` and confirm test gate and build jobs succeed (upload steps will fail until Trusted Publisher is configured on pypi.org — expected)
- [ ] Confirm `twine check` passes on a local `uv build` output
- [ ] Confirm `release.yml` categories are correct

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)