### PR TITLE
Bump-and-tag workflow: automated version increment and GitHub Release

### DIFF
--- a/.github/workflows/bump-and-tag.yml
+++ b/.github/workflows/bump-and-tag.yml
@@ -118,6 +118,7 @@ jobs:
           echo "Tag ${TAG} is free to create."
 
       - name: Update pyproject.toml
+        # inputs.dry_run is null on push events, which correctly evaluates != true
         if: ${{ inputs.dry_run != true }}
         run: |
           python3 - <<'EOF'
@@ -142,6 +143,7 @@ jobs:
           NEXT_VERSION: ${{ steps.next-version.outputs.next_version }}
 
       - name: Commit, tag, and push
+        # inputs.dry_run is null on push events, which correctly evaluates != true
         if: ${{ inputs.dry_run != true }}
         run: |
           TAG="v${{ steps.next-version.outputs.next_version }}"
@@ -152,6 +154,7 @@ jobs:
           git push origin "${TAG}"
 
       - name: Create GitHub Release
+        # inputs.dry_run is null on push events, which correctly evaluates != true
         if: ${{ inputs.dry_run != true }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump-and-tag.yml
+++ b/.github/workflows/bump-and-tag.yml
@@ -1,0 +1,170 @@
+name: Bump and Tag
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run — log calculations without making any git changes"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  bump-and-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine bump type from PR labels
+        id: bump-type
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 - <<'EOF'
+          import json, os, subprocess, sys, urllib.request
+
+          sha = os.environ["GITHUB_SHA"]
+          repo = os.environ["GITHUB_REPOSITORY"]
+          token = os.environ["GH_TOKEN"]
+
+          url = f"https://api.github.com/repos/{repo}/commits/{sha}/pulls"
+          req = urllib.request.Request(url, headers={
+              "Authorization": f"Bearer {token}",
+              "Accept": "application/vnd.github+json",
+              "X-GitHub-Api-Version": "2022-11-28",
+          })
+          with urllib.request.urlopen(req) as resp:
+              prs = json.loads(resp.read())
+
+          if not prs:
+              print("::warning::No PR associated with this commit — defaulting to patch bump", flush=True)
+              labels = []
+          else:
+              labels = [lbl["name"] for lbl in prs[0]["labels"]]
+              print(f"PR #{prs[0]['number']} labels: {labels}", flush=True)
+
+          bump = "patch"
+          for level in ("major", "minor", "patch"):
+              if f"release: {level}" in labels:
+                  bump = level
+                  break
+          else:
+              print("::warning::No release: label found — defaulting to patch bump", flush=True)
+
+          print(f"Resolved bump type: {bump}", flush=True)
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"bump_type={bump}\n")
+          EOF
+
+      - name: Calculate next version
+        id: next-version
+        run: |
+          python3 - <<'EOF'
+          import os, re
+
+          with open("pyproject.toml") as f:
+              content = f.read()
+
+          m = re.search(r'^version = "(\d+)\.(\d+)\.(\d+)"', content, re.MULTILINE)
+          if not m:
+              print("::error::Could not find version in pyproject.toml", flush=True)
+              raise SystemExit(1)
+
+          major, minor, patch = int(m.group(1)), int(m.group(2)), int(m.group(3))
+          current = f"{major}.{minor}.{patch}"
+          bump = os.environ["BUMP_TYPE"]
+
+          if bump == "major":
+              next_ver = f"{major + 1}.0.0"
+          elif bump == "minor":
+              next_ver = f"{major}.{minor + 1}.0"
+          else:
+              next_ver = f"{major}.{minor}.{patch + 1}"
+
+          print(f"Current version: {current}", flush=True)
+          print(f"Next version:    {next_ver}", flush=True)
+          print(f"Commit message:  chore: bump version to v{next_ver}", flush=True)
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"current_version={current}\n")
+              f.write(f"next_version={next_ver}\n")
+          EOF
+        env:
+          BUMP_TYPE: ${{ steps.bump-type.outputs.bump_type }}
+
+      - name: Check tag does not already exist
+        run: |
+          TAG="v${{ steps.next-version.outputs.next_version }}"
+          if git ls-remote --tags origin | grep -q "refs/tags/${TAG}$"; then
+            echo "::error::Tag ${TAG} already exists — aborting to avoid duplicate release" >&2
+            exit 1
+          fi
+          echo "Tag ${TAG} is free to create."
+
+      - name: Update pyproject.toml
+        if: ${{ inputs.dry_run != true }}
+        run: |
+          python3 - <<'EOF'
+          import os, re
+
+          next_ver = os.environ["NEXT_VERSION"]
+          with open("pyproject.toml") as f:
+              content = f.read()
+
+          new_content = re.sub(
+              r'^(version = ")[^"]+(")',
+              rf'\g<1>{next_ver}\g<2>',
+              content,
+              flags=re.MULTILINE,
+          )
+          with open("pyproject.toml", "w") as f:
+              f.write(new_content)
+
+          print(f"Updated pyproject.toml to version {next_ver}", flush=True)
+          EOF
+        env:
+          NEXT_VERSION: ${{ steps.next-version.outputs.next_version }}
+
+      - name: Commit, tag, and push
+        if: ${{ inputs.dry_run != true }}
+        run: |
+          TAG="v${{ steps.next-version.outputs.next_version }}"
+          git add pyproject.toml
+          git commit -m "chore: bump version to ${TAG}"
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin main
+          git push origin "${TAG}"
+
+      - name: Create GitHub Release
+        if: ${{ inputs.dry_run != true }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.next-version.outputs.next_version }}"
+          gh release create "${TAG}" --generate-notes
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry_run == true }}
+        run: |
+          echo "=== DRY RUN — no changes made ==="
+          echo "Bump type:       ${{ steps.bump-type.outputs.bump_type }}"
+          echo "Current version: ${{ steps.next-version.outputs.current_version }}"
+          echo "Next version:    ${{ steps.next-version.outputs.next_version }}"
+          echo "Would create tag: v${{ steps.next-version.outputs.next_version }}"
+          echo "Would commit:    chore: bump version to v${{ steps.next-version.outputs.next_version }}"

--- a/bank2ynab/__init__.py
+++ b/bank2ynab/__init__.py
@@ -1,0 +1,6 @@
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("bank2ynab")
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
   "chardet>=4.0.0,<6.0.0",

--- a/test/unit/test_bump_and_tag.py
+++ b/test/unit/test_bump_and_tag.py
@@ -1,0 +1,72 @@
+"""Unit tests for bump-and-tag version logic (mirrors workflow inline Python)."""
+
+
+
+def bump_version(current: str, bump_type: str) -> str:
+    """Increment a semver string by bump_type (patch/minor/major)."""
+    major, minor, patch = (int(x) for x in current.split("."))
+    if bump_type == "major":
+        return f"{major + 1}.0.0"
+    if bump_type == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def resolve_bump_type(labels: list[str]) -> str:
+    """Return the highest release bump type from a list of label names."""
+    for level in ("major", "minor", "patch"):
+        if f"release: {level}" in labels:
+            return level
+    return "patch"
+
+
+class TestBumpVersion:
+    def test_patch_bump(self):
+        assert bump_version("1.2.3", "patch") == "1.2.4"
+
+    def test_minor_bump(self):
+        assert bump_version("1.2.3", "minor") == "1.3.0"
+
+    def test_major_bump(self):
+        assert bump_version("1.2.3", "major") == "2.0.0"
+
+    def test_patch_resets_nothing(self):
+        assert bump_version("1.2.9", "patch") == "1.2.10"
+
+    def test_minor_zeros_patch(self):
+        assert bump_version("1.2.3", "minor") == "1.3.0"
+
+    def test_major_zeros_minor_and_patch(self):
+        assert bump_version("1.2.3", "major") == "2.0.0"
+
+    def test_from_zero_minor(self):
+        assert bump_version("1.0.0", "patch") == "1.0.1"
+
+
+class TestResolveBumpType:
+    def test_no_release_labels_defaults_to_patch(self):
+        assert resolve_bump_type([]) == "patch"
+
+    def test_patch_label(self):
+        assert resolve_bump_type(["release: patch"]) == "patch"
+
+    def test_minor_label(self):
+        assert resolve_bump_type(["release: minor"]) == "minor"
+
+    def test_major_label(self):
+        assert resolve_bump_type(["release: major"]) == "major"
+
+    def test_major_wins_over_minor(self):
+        assert resolve_bump_type(["release: minor", "release: major"]) == "major"
+
+    def test_major_wins_over_patch(self):
+        assert resolve_bump_type(["release: patch", "release: major"]) == "major"
+
+    def test_minor_wins_over_patch(self):
+        assert resolve_bump_type(["release: patch", "release: minor"]) == "minor"
+
+    def test_unrelated_labels_ignored(self):
+        assert resolve_bump_type(["bug", "enhancement"]) == "patch"
+
+    def test_mixed_labels(self):
+        assert resolve_bump_type(["bug", "release: minor", "AFK"]) == "minor"

--- a/test/unit/test_version.py
+++ b/test/unit/test_version.py
@@ -1,0 +1,19 @@
+import re
+
+import pytest
+
+
+def test_version_is_semver():
+    try:
+        import importlib.metadata
+
+        importlib.metadata.version("bank2ynab")
+    except importlib.metadata.PackageNotFoundError:
+        pytest.skip("package not installed; run pip install -e . to enable")
+
+    import bank2ynab
+
+    assert bank2ynab.__version__ != "unknown", "__version__ should be set when package is installed"
+    assert re.match(
+        r"^\d+\.\d+\.\d+$", bank2ynab.__version__
+    ), f"__version__ should be semver, got {bank2ynab.__version__!r}"

--- a/test/unit/test_version.py
+++ b/test/unit/test_version.py
@@ -1,12 +1,11 @@
 import re
+import importlib.metadata
 
 import pytest
 
 
 def test_version_is_semver():
     try:
-        import importlib.metadata
-
         importlib.metadata.version("bank2ynab")
     except importlib.metadata.PackageNotFoundError:
         pytest.skip("package not installed; run pip install -e . to enable")


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/bump-and-tag.yml` triggered on push to `main` and via `workflow_dispatch`
- Reads the highest `release:` label (`major`/`minor`/`patch`) from the triggering PR via the GitHub API, defaulting to `patch` with a warning when none found
- Bumps version in `pyproject.toml` using inline Python, commits to `main`, creates annotated tag and GitHub Release with auto-generated notes
- Supports `dry_run` boolean input that runs all calculations and logs results without making any git changes

## Test plan
- [ ] Trigger workflow manually with `dry_run: true` via Actions → bump-and-tag → Run workflow
- [ ] Verify logs show: detected labels, current version, calculated next version, would-be commit message
- [ ] Verify no commit, tag, or release is created in dry-run mode
- [ ] Test label scenarios: no label (→ patch with warning), `release: minor`, both `release: major` + `release: patch` (→ major wins)
- [ ] Test duplicate-tag scenario: pre-create the target tag and confirm workflow exits with a clear error
- [ ] Confirm `uv run python -m pytest` passes (16 new unit tests for bump/label logic)

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)