### PR TITLE
Contributor experience: release docs, PR template, README

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,4 +15,4 @@
 
 **Checklist**
 
-- [ ] If this is a `develop → main` release PR, apply a `release:` label (`release: patch`, `release: minor`, or `release: major`) before merging. See [CONTRIBUTING.md](../CONTRIBUTING.md#release-label-semantics) for details.
+- [ ] **Release PRs only (`develop → main`):** apply a `release:` label (`release: patch`, `release: minor`, or `release: major`) before merging — skip this for regular feature/fix PRs. See [CONTRIBUTING.md](../CONTRIBUTING.md#release-label-semantics) for details.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,9 @@
 
 **Explain the changes that this pull request makes**
 *Note that submitted code must pass Ruff linting. Please review automated lint results on your pull request and fix failures before requesting review. Local command: `uvx ruff check . --select F,E9,I`.*
+
+---
+
+**Checklist**
+
+- [ ] If this is a `develop → main` release PR, apply a `release:` label (`release: patch`, `release: minor`, or `release: major`) before merging. See [CONTRIBUTING.md](../CONTRIBUTING.md#release-label-semantics) for details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,5 +145,6 @@ abort with an error.
 4. Click **Run workflow**.
 
 The workflow will re-run against the existing tag and publish the distribution.
-If TestPyPI already has the version, the TestPyPI step may fail — that is
-expected and harmless; the PyPI publish step will still proceed.
+If TestPyPI already has the version, the TestPyPI publish step will fail but
+is marked `continue-on-error: true`, so the job continues and the PyPI
+publish step will still run.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,149 @@
+# Contributing to bank2ynab
+
+Thank you for taking the time to contribute!
+
+For general contribution guidelines — bug reports, feature requests, code style,
+and pull-request process — see [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).
+
+This document covers the **release process** for maintainers.
+
+---
+
+## Table of Contents
+
+- [Release Flow](#release-flow)
+- [release: Label Semantics](#release-label-semantics)
+- [One-Time Setup Checklist](#one-time-setup-checklist)
+- [Dry-Run Instructions](#dry-run-instructions)
+- [Manual Recovery Runbook](#manual-recovery-runbook)
+
+---
+
+## Release Flow
+
+Releases follow a `develop → main` promotion model:
+
+1. Open a pull request from `develop` to `main`.
+2. Apply **exactly one** `release:` label to the PR (see [label semantics](#release-label-semantics)).
+3. Merge the PR.
+4. The `Bump and Tag` workflow (`bump-and-tag.yml`) triggers automatically on
+   push to `main`. It reads the merged PR's labels, calculates the next
+   semantic version, updates `pyproject.toml`, commits the bump, creates an
+   annotated git tag (e.g. `v1.2.3`), pushes both to `main`, and opens a
+   GitHub Release with auto-generated release notes.
+5. The tag push triggers the `Publish to PyPI` workflow (`publish.yml`). It
+   runs the test suite, builds the distribution, publishes to TestPyPI, verifies
+   the install, then publishes to PyPI — all using Trusted Publisher (OIDC),
+   so no PyPI API token is required.
+
+---
+
+## release: Label Semantics
+
+| Label | Version bump | Example |
+|-------|-------------|---------|
+| `release: patch` | `x.y.Z → x.y.(Z+1)` | `1.2.3 → 1.2.4` |
+| `release: minor` | `x.Y.z → x.(Y+1).0` | `1.2.3 → 1.3.0` |
+| `release: major` | `X.y.z → (X+1).0.0` | `1.2.3 → 2.0.0` |
+
+**Highest wins.** If multiple labels are applied, the workflow picks the most
+significant one (`major > minor > patch`).
+
+**Default on direct push.** If a commit is pushed directly to `main` without
+an associated PR (or the PR has no `release:` label), the workflow defaults to
+`patch` and emits a warning in the Actions log. Prefer labelled PRs to avoid
+surprises.
+
+---
+
+## One-Time Setup Checklist
+
+These steps are required before the release pipeline can publish to PyPI.
+Complete them once when setting up the repository (or after a fork).
+
+### PyPI Trusted Publisher
+
+Register a Trusted Publisher on **pypi.org**:
+
+1. Log in to [pypi.org](https://pypi.org) and go to
+   **Account settings → Publishing → Add a new pending publisher**.
+2. Fill in:
+   - **PyPI project name:** `bank2ynab`
+   - **Owner:** `bank2ynab`
+   - **Repository:** `bank2ynab`
+   - **Workflow filename:** `publish.yml`
+   - **Environment name:** `pypi`
+3. Save.
+
+Register the same configuration on **test.pypi.org**:
+
+1. Log in to [test.pypi.org](https://test.pypi.org) and go to
+   **Account settings → Publishing → Add a new pending publisher**.
+2. Use the same values as above.
+3. Save.
+
+### GitHub Labels
+
+Create the following labels in the repository
+(**Settings → Labels → New label**):
+
+| Label name | Colour |
+|------------|--------|
+| `release: patch` | `#0075ca` |
+| `release: minor` | `#e4e669` |
+| `release: major` | `#d73a4a` |
+
+### GitHub Environment
+
+Create the `pypi` deployment environment
+(**Settings → Environments → New environment**):
+
+1. Name it exactly `pypi`.
+2. Optionally add protection rules (e.g. require a reviewer before publishing).
+3. Save — no secrets needed; Trusted Publisher uses OIDC.
+
+---
+
+## Dry-Run Instructions
+
+To preview what version would be calculated without making any changes:
+
+1. Go to **Actions → Bump and Tag → Run workflow**.
+2. Select the `main` branch.
+3. Check the **Dry run** checkbox.
+4. Click **Run workflow**.
+
+The workflow logs will show:
+- The bump type resolved from the most recent merged PR's labels
+- The current version read from `pyproject.toml`
+- The next version that would be created
+- The tag and commit message that would be written
+
+No files are changed, no tags are created, and `publish.yml` is not triggered.
+
+---
+
+## Manual Recovery Runbook
+
+Use this runbook when `publish.yml` fails **after** the tag has already been
+created by `bump-and-tag.yml`.
+
+**Symptom:** The `Publish to PyPI` workflow failed (e.g. a transient network
+error during upload) but the git tag `vX.Y.Z` already exists.
+
+**Do not re-run `bump-and-tag.yml`** — it will detect the existing tag and
+abort with an error.
+
+**Recovery steps:**
+
+1. Investigate the failure in **Actions → Publish to PyPI** and fix the
+   root cause (e.g. confirm PyPI Trusted Publisher is configured, check the
+   environment name is `pypi`).
+2. Go to **Actions → Publish to PyPI → Run workflow**.
+3. In the **Use workflow from** dropdown, select **Tags** and choose the
+   existing tag (e.g. `v1.2.3`).
+4. Click **Run workflow**.
+
+The workflow will re-run against the existing tag and publish the distribution.
+If TestPyPI already has the version, the TestPyPI step may fail — that is
+expected and harmless; the PyPI publish step will still proceed.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This project consolidates other conversion efforts into one universal tool that 
 - [User Guide](#userguide)
 - [YNAB API Import](#api)
 - [Contributors](#contributors)
+- [Releases](#releases)
 - [Known Bugs](#knownbugs)
 - [List of Supported Banks](#formats)
 
@@ -121,6 +122,12 @@ Notes:
 ## <a name="contributors"></a>Contributors
 
 [![Contributors](https://contrib.rocks/image?repo=bank2ynab/bank2ynab)](https://github.com/bank2ynab/bank2ynab/graphs/contributors)
+
+## <a name="releases"></a>Releases
+
+Releases are published to [PyPI](https://pypi.org/project/bank2ynab/) automatically when a `develop → main` PR is merged with a `release:` label.
+
+For the full release process — including the `develop → main` flow, `release:` label semantics, one-time setup, dry-run instructions, and a manual recovery runbook — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## <a name="knownbugs"></a>Known Bugs
 


### PR DESCRIPTION
## Summary
- Adds CONTRIBUTING.md with full release process documentation, one-time setup checklist, and manual recovery runbook
- Adds .github/pull_request_template.md with Description, Related issues, and release label reminder checklist
- Updates README.md with a Releases section pointing to CONTRIBUTING.md

## Test plan
- [ ] Read CONTRIBUTING.md from scratch: can a new maintainer perform a release without asking anyone?
- [ ] Verify setup checklist matches actual workflow filenames/environment names in publish.yml and bump-and-tag.yml
- [ ] Verify PR template renders correctly on GitHub
- [ ] Confirm `pip install bank2ynab` is present and unchanged in README.md
- [ ] `uv run python -m pytest` passes

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)