### PR TITLE
fix: treat Unicode minus sign (U+2212) as a negative sign in monetary parsing (#527)

### DIFF
--- a/bank2ynab/dataframe_handler.py
+++ b/bank2ynab/dataframe_handler.py
@@ -368,6 +368,9 @@ def _parse_monetary_string(value: object) -> float:
     s = str(value).strip()
     if not s:
         return 0.0
+    # normalise the Unicode minus sign (U+2212) to an ASCII hyphen so it is
+    # kept as a sign below instead of being stripped as a stray symbol
+    s = s.replace("\u2212", "-")
     # normalise thousands/decimal separators: convert commas to periods, then
     # remove all but the last period so "1.234.567,89" → "1234567.89"
     s = s.replace(",", ".")

--- a/test/unit/test_optimisations.py
+++ b/test/unit/test_optimisations.py
@@ -103,6 +103,13 @@ class TestParseMonetaryString:
     def test_negative_value(self):
         assert _parse_monetary_string("-42.50") == pytest.approx(-42.50)
 
+    def test_unicode_minus_sign(self):
+        """U+2212 minus sign is parsed as negative, not stripped (#527)."""
+        assert _parse_monetary_string("−123.45") == pytest.approx(-123.45)
+
+    def test_unicode_minus_sign_with_thousands(self):
+        assert _parse_monetary_string("−1.234,56") == pytest.approx(-1234.56)
+
     def test_integer_string(self):
         assert _parse_monetary_string("100") == pytest.approx(100.0)
 


### PR DESCRIPTION
**New Pull Request**

**Reference Issue:**
#527

**Description**

SE Morrow Bank exports use the Unicode minus sign U+2212 instead of the ASCII hyphen. `_parse_monetary_string()` strips U+2212 as a stray symbol, so "−123.45" is parsed as +123.45 and every negative row is imported into YNAB as an inflow. Confirmed on HEAD 4fa82e9.

**Explain the changes that this pull request makes**

The sanitizing step in `_parse_monetary_string()` keeps only digits, periods, and the ASCII hyphen. This PR normalizes U+2212 to an ASCII hyphen before that step, so the sign survives parsing. One line of code plus a comment.

Two regression tests added to `TestParseMonetaryString`. Both fail without the fix and pass with it:

```
$ python -m pytest test/unit/test_optimisations.py -k unicode_minus -q   # before fix
FAILED test/unit/test_optimisations.py::TestParseMonetaryString::test_unicode_minus_sign
FAILED test/unit/test_optimisations.py::TestParseMonetaryString::test_unicode_minus_sign_with_thousands

$ python -m pytest test/unit/test_optimisations.py -k unicode_minus -q   # after fix
2 passed, 33 deselected

$ python -m pytest test/ -q
66 passed, 16 skipped, 29 subtests passed
```

`ruff check . --select F,E9,I` passes.

No behavior change for values that do not contain U+2212.

---
Assisted-by: Claude (code generation, reviewed and tested locally)